### PR TITLE
Fix: Update CodeBlock syntax highlighter style import path

### DIFF
--- a/sv-uvm-guide/src/components/ui/CodeBlock.tsx
+++ b/sv-uvm-guide/src/components/ui/CodeBlock.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect } from "react";
 import { PrismAsyncLight as SyntaxHighlighter } from "react-syntax-highlighter";
 // Choosing a dark theme for code blocks, can be customized or made theme-aware
-import { okaidia } from "react-syntax-highlighter/dist/esm/styles/prism"; // Changed to okaidia
+import { okaidia } from "react-syntax-highlighter/dist/cjs/styles/prism"; // Changed to cjs path
 import { Copy, Check } from "lucide-react";
 import { Button } from "./Button"; // Using our existing Button component
 


### PR DESCRIPTION
Changed the import path for the 'okaidia' style in CodeBlock.tsx from 'react-syntax-highlighter/dist/esm/styles/prism' to 'react-syntax-highlighter/dist/cjs/styles/prism'.

This resolves a 'Module not found' error encountered in local development environments, suggesting the 'cjs' path is more robust for style imports in this Next.js project setup.