### PR TITLE
Fix: Use direct default import for CodeBlock style

### DIFF
--- a/sv-uvm-guide/src/components/ui/CodeBlock.tsx
+++ b/sv-uvm-guide/src/components/ui/CodeBlock.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect } from "react";
 import { PrismAsyncLight as SyntaxHighlighter } from "react-syntax-highlighter";
 // Choosing a dark theme for code blocks, can be customized or made theme-aware
-import { okaidia } from "react-syntax-highlighter/dist/cjs/styles/prism"; // Changed to cjs path
+import okaidia from "react-syntax-highlighter/dist/cjs/styles/prism/okaidia"; // Direct import of okaidia style
 import { Copy, Check } from "lucide-react";
 import { Button } from "./Button"; // Using our existing Button component
 


### PR DESCRIPTION
Updated CodeBlock.tsx to import the 'okaidia' syntax highlighting style using a direct default import:
`import okaidia from 'react-syntax-highlighter/dist/cjs/styles/prism/okaidia';`

This replaces the previous named import from the directory index, e.g., `import { okaidia } from 'react-syntax-highlighter/dist/cjs/styles/prism';`

The direct import of the specific style file is more robust and should resolve 'Module not found' errors encountered in local development environments.