### PR TITLE
fix: Correct CSS syntax and MainLayout import path

### DIFF
--- a/sv-uvm-guide/src/app/globals.css
+++ b/sv-uvm-guide/src/app/globals.css
@@ -11,8 +11,8 @@
     --primary-foreground-hsl: 210 40% 98%;
 
     /* Digital Blueprint HSL values (if needed for direct CSS var usage) */
-    /* Example: --db-background-hsl: 217 68% 11%; /* #0A192F */ */
-    /* --db-primary-text-hsl: 210 100% 95%; /* #E6F1FF */ */
+    /* Example: --db-background-hsl: 217 68% 11%; (Value for #0A192F) */
+    /* --db-primary-text-hsl: 210 100% 95%; (Value for #E6F1FF) */
 
   }
 

--- a/sv-uvm-guide/src/app/layout.tsx
+++ b/sv-uvm-guide/src/app/layout.tsx
@@ -4,7 +4,7 @@ import localFont from 'next/font/local';
 import { AnimatePresence } from 'framer-motion'; // Import AnimatePresence
 import "./globals.css";
 // Navbar and Footer are now part of MainLayout
-import MainLayout from "@/components/layout/MainLayout"; // Import MainLayout
+import MainLayout from "@/app/components/layout/MainLayout"; // Corrected Import MainLayout path
 import { AuthProvider } from "@/contexts/AuthContext";
 // The AIAssistant (full chat) is removed from global layout for now.
 // The PersistentAITutorButton will be the global widget.


### PR DESCRIPTION
- Removed nested comments in globals.css to fix syntax error.
- Updated the import path for MainLayout in layout.tsx to correctly resolve to src/app/components/layout/MainLayout.tsx.