### PR TITLE
debug: Simplify Tailwind config to isolate color utility error

### DIFF
--- a/sv-uvm-guide/tailwind.config.ts
+++ b/sv-uvm-guide/tailwind.config.ts
@@ -11,44 +11,12 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
+        // Digital Blueprint Colors
         background: '#0A192F',
-        'brand-text-primary': '#E6F1FF', // Renamed from 'primary-text'
+        'brand-text-primary': '#E6F1FF',
         accent: '#64FFDA',
         'secondary-accent': '#FFCA86',
-        // Keeping other existing colors for now, can be cleaned up later if not used
-        border: "hsl(var(--border-hsl))",
-        input: "hsl(var(--input-hsl))",
-        ring: "hsl(var(--ring-hsl))",
-        foreground: "hsl(var(--foreground-hsl))",
-        primary: {
-          DEFAULT: "hsl(var(--primary-hsl))",
-          foreground: "hsl(var(--primary-foreground-hsl))",
-        },
-        secondary: {
-          DEFAULT: "hsl(var(--secondary-hsl, 240 4.8% 95.9%))",
-          foreground: "hsl(var(--secondary-foreground-hsl, 240 5.9% 10%))",
-        },
-        destructive: {
-          DEFAULT: "hsl(var(--destructive-hsl, 0 84.2% 60.2%))",
-          foreground: "hsl(var(--destructive-foreground-hsl, 0 0% 98%))",
-        },
-        muted: {
-          DEFAULT: "hsl(var(--muted-hsl, 240 4.8% 95.9%))",
-          foreground: "hsl(var(--muted-foreground-hsl, 240 3.8% 46.1%))",
-        },
-        // 'accent' is now defined above, so this can be removed or aliased if needed
-        // accent: {
-        //   DEFAULT: "hsl(var(--accent-hsl, 240 4.8% 95.9%))",
-        //   foreground: "hsl(var(--accent-foreground-hsl, 240 5.9% 10%))",
-        // },
-        popover: {
-          DEFAULT: "hsl(var(--popover-hsl, 0 0% 100%))",
-          foreground: "hsl(var(--popover-foreground-hsl, 240 10% 3.9%))",
-        },
-        card: {
-          DEFAULT: "hsl(var(--card-hsl, 0 0% 100%))",
-          foreground: "hsl(var(--card-foreground-hsl, 240 10% 3.9%))",
-        },
+        // Simplified: Remove HSL-based colors for now to test
       },
       fontFamily: {
         sans: ['"Cal Sans"', ...fontFamily.sans],


### PR DESCRIPTION
Simplified the colors configuration in `tailwind.config.ts` to only include the essential Digital Blueprint colors. This is an attempt to isolate the cause of the "Cannot apply unknown utility class `text-brand-text-primary`" error.