### PR TITLE
debug: Remove @apply rules from globals.css for body and headings

### DIFF
--- a/sv-uvm-guide/src/app/globals.css
+++ b/sv-uvm-guide/src/app/globals.css
@@ -25,15 +25,19 @@
   }
 
   body {
-    @apply bg-background text-brand-text-primary font-body;
-    /* Subtle grid pattern */
+    /* Base styles are applied via className in layout.tsx */
+    /* @apply bg-background text-brand-text-primary font-body; */
+
+    /* Subtle grid pattern - this can remain */
     background-image: linear-gradient(rgba(100, 255, 218, 0.05) 1px, transparent 1px),
                       linear-gradient(90deg, rgba(100, 255, 218, 0.05) 1px, transparent 1px);
     background-size: 20px 20px;
   }
 
   h1, h2, h3, h4, h5, h6 {
-    @apply font-sans;
+    /* font-family is set to font-sans in tailwind.config.ts for 'sans' key */
+    /* This will be picked up by default or via typography plugin if headings are styled by prose */
+    /* @apply font-sans; */
   }
 }
 


### PR DESCRIPTION
Further debugging step for Tailwind CSS processing issues. Removed @apply rules for body and h1-h6 in globals.css.
- Body base styles are already applied via className in layout.tsx.
- Heading font should be inherited from Tailwind's sans-serif default, configured in tailwind.config.ts.