### PR TITLE
debug: Change postcss config to use 'tailwindcss' directly for diagno…

### DIFF
--- a/sv-uvm-guide/postcss.config.js
+++ b/sv-uvm-guide/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    '@tailwindcss/postcss': {},
+    'tailwindcss': {}, // Changed from '@tailwindcss/postcss' for diagnostics
     'autoprefixer': {}
   }
 };


### PR DESCRIPTION
…stics

Changed postcss.config.js to use 'tailwindcss' instead of '@tailwindcss/postcss' as a diagnostic step to investigate CSS processing issues with Tailwind v4.