### PR TITLE
debug: Revert postcss.config and broaden tailwind content paths

### DIFF
--- a/sv-uvm-guide/postcss.config.js
+++ b/sv-uvm-guide/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    'tailwindcss': {}, // Changed from '@tailwindcss/postcss' for diagnostics
+    '@tailwindcss/postcss': {},
     'autoprefixer': {}
   }
 };

--- a/sv-uvm-guide/tailwind.config.ts
+++ b/sv-uvm-guide/tailwind.config.ts
@@ -3,9 +3,11 @@ import { fontFamily } from "tailwindcss/defaultTheme";
 
 const config: Config = {
   content: [
-    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}", // Primary location for App Router
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}", // If you have a global src/components
+    "./app/**/*.{js,ts,jsx,tsx,mdx}", // If components are in a root /app folder (less common with src)
+    "./components/**/*.{js,ts,jsx,tsx,mdx}", // If components are in a root /components folder
+    // Add any other top-level directories that might contain JSX/TSX using Tailwind classes
   ],
   darkMode: "class",
   theme: {


### PR DESCRIPTION
- Reverted postcss.config.js to use '@tailwindcss/postcss' as required by Tailwind v4.
- Broadened the content scanning paths in tailwind.config.ts to be more explicit in an attempt to resolve issues with Tailwind styles not applying.