### PR TITLE
fix: Correctly comment out original content in page.tsx for diagnostic

### DIFF
--- a/sv-uvm-guide/src/app/page.tsx
+++ b/sv-uvm-guide/src/app/page.tsx
@@ -18,12 +18,12 @@ export default function Home() {
       </div>
     // </React.Fragment>
 
-      /*
-      // Original Page Content - Temporarily commented out for debugging JSX error
-      <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-        <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-          <Image
-      */
+    /*
+    // Original Page Content - Temporarily commented out for debugging JSX error
+    // The entire block below is now commented out.
+    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
+      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
+        <Image
           className="dark:invert"
           src="/next.svg"
           alt="Next.js logo"
@@ -118,5 +118,6 @@ export default function Home() {
         </a>
       </footer>
     </div>
+    */
   );
 }


### PR DESCRIPTION
Ensured the original JSX content in `src/app/page.tsx` is fully commented out to isolate the Tailwind diagnostic div and resolve the previous JSX syntax error.