### PR TITLE
feat: Implement Phase 2 curriculum architecture and initial content

### DIFF
--- a/sv-uvm-guide/content/curriculum/sv-advanced/object-oriented-programming/inheritance-polymorphism-virtual-methods.mdx
+++ b/sv-uvm-guide/content/curriculum/sv-advanced/object-oriented-programming/inheritance-polymorphism-virtual-methods.mdx
@@ -1,0 +1,179 @@
+---
+id: 'sv-advanced-oop-inheritance'
+title: 'Inheritance, Polymorphism, and Virtual Methods'
+---
+
+Object-Oriented Programming (OOP) is a cornerstone of modern SystemVerilog verification methodologies, particularly UVM. Key OOP concepts like inheritance, polymorphism, and virtual methods allow for the creation of flexible, reusable, and extensible verification components.
+
+## Theory
+
+(Reference: IEEE 1800-2017 Standard, Clause 8: Classes)
+
+### Inheritance (`extends`)
+
+*   **Concept:** Inheritance allows a new class (called a *derived class* or *subclass*) to acquire the properties (data members) and methods (functions/tasks) of an existing class (called a *base class* or *superclass*). This promotes code reuse and establishes an "is-a" relationship (e.g., an `EthPacket` *is a* type of `Packet`).
+*   **Syntax:** Achieved using the `extends` keyword.
+    ```systemverilog
+    class BaseClass;
+      // members and methods
+    endclass
+
+    class DerivedClass extends BaseClass;
+      // additional members and methods
+      // can also override base class methods
+    endclass
+    ```
+*   **`super` keyword:** Used within a derived class to call methods or access members of the base class, particularly useful for invoking the base class constructor (`super.new()`).
+
+### Polymorphism
+
+*   **Concept:** Polymorphism (literally "many forms") allows a base class handle (pointer or reference) to hold an object of any of its derived classes. This means you can write code that operates on base class handles, and it will behave correctly regardless of the actual derived class object being pointed to at runtime.
+*   **Example:** If `Packet` is a base class and `EthPacket` and `UsbPacket` are derived classes, a variable of type `Packet` can hold an instance of `Packet`, `EthPacket`, or `UsbPacket`.
+    ```systemverilog
+    Packet p;
+    EthPacket eth_p = new();
+    UsbPacket usb_p = new();
+
+    p = eth_p; // Base class handle holds derived class object
+    p.some_method(); // Behavior depends on the actual object type if some_method is virtual
+
+    p = usb_p;
+    p.some_method();
+    ```
+
+### Virtual Methods
+
+*   **Concept:** When a base class handle holds a derived class object, and a method is called on that handle, a virtual method ensures that the derived class's implementation of that method is executed, not the base class's. This is crucial for achieving true polymorphic behavior. If a method is *not* virtual, the base class's version is always called, regardless of the object's actual type.
+*   **Syntax:** The `virtual` keyword is used in the base class when declaring the method. Derived classes that override this method do not need to repeat the `virtual` keyword (though it's not an error if they do).
+    ```systemverilog
+    class Packet;
+      virtual function void print(); // Declared as virtual
+        $display("Generic Packet");
+      endfunction
+    endclass
+
+    class EthPacket extends Packet;
+      // Override the print method
+      virtual function void print(); // 'virtual' here is optional but good practice
+        $display("Ethernet Packet");
+      endfunction
+    endclass
+    ```
+*   **Late Binding:** Virtual methods enable "late binding" or "dynamic dispatch," where the decision of which method implementation to execute is made at runtime based on the actual object type, not at compile time based on the handle type.
+
+## Example: Packet Hierarchy
+
+This example demonstrates inheritance, polymorphism, and virtual methods with a simple packet hierarchy.
+
+```systemverilog
+// Base class Packet
+class Packet;
+  string name;
+
+  function new(string name = "Packet");
+    this.name = name;
+  endfunction
+
+  // Virtual method to display packet information
+  virtual function void print();
+    $display("[%s] Generic packet data", name);
+  endfunction
+
+  function void common_processing();
+    $display("[%s] Performing common packet processing.", name);
+  endfunction
+endclass
+
+// Derived class EthPacket
+class EthPacket extends Packet;
+  int eth_type;
+
+  function new(string name = "EthPacket", int eth_type = 'h0800);
+    super.new(name); // Call base class constructor
+    this.eth_type = eth_type;
+  endfunction
+
+  // Override the virtual print method
+  virtual function void print();
+    super.print(); // Optionally call base class method
+    $display("[%s] Ethernet Type: 0x%0h", name, eth_type);
+  endfunction
+
+  function void eth_specific_feature();
+    $display("[%s] Executing Ethernet-specific feature.", name);
+  endfunction
+endclass
+
+// Derived class UsbPacket
+class UsbPacket extends Packet;
+  typedef enum { BULK, INTERRUPT, ISOCHRONOUS } usb_transfer_type;
+  usb_transfer_type transfer_type;
+
+  function new(string name = "UsbPacket", usb_transfer_type type = BULK);
+    super.new(name);
+    this.transfer_type = type;
+  endfunction
+
+  // Override the virtual print method
+  virtual function void print();
+    super.print();
+    $display("[%s] USB Transfer Type: %s", name, transfer_type.name());
+  endfunction
+
+  function void usb_specific_feature();
+    $display("[%s] Executing USB-specific feature.", name);
+  endfunction
+endclass
+
+// Test module
+module oop_example_test;
+  initial begin
+    Packet      pkt_array[3]; // Array of base class handles
+    Packet      generic_pkt;
+    EthPacket   eth_pkt;
+    UsbPacket   usb_pkt;
+
+    // Create objects of different types
+    generic_pkt = new("GenericPkt");
+    eth_pkt     = new("EthPkt0", 'h86DD); // IPv6 EtherType
+    usb_pkt     = new("UsbPkt0", UsbPacket::INTERRUPT);
+
+    // Polymorphism: Assign derived class objects to base class handles
+    pkt_array[0] = generic_pkt;
+    pkt_array[1] = eth_pkt;
+    pkt_array[2] = usb_pkt;
+
+    $display("--- Calling virtual print() method on each packet in array ---");
+    foreach (pkt_array[i]) begin
+      if (pkt_array[i] != null) begin
+        pkt_array[i].print(); // Calls the appropriate derived class print()
+        pkt_array[i].common_processing(); // Calls base class method
+
+        // To call derived-class specific methods, we need to downcast safely
+        EthPacket temp_eth_pkt;
+        UsbPacket temp_usb_pkt;
+
+        if ($cast(temp_eth_pkt, pkt_array[i])) begin // Check if it's an EthPacket
+          temp_eth_pkt.eth_specific_feature();
+        end else if ($cast(temp_usb_pkt, pkt_array[i])) begin // Check if it's a UsbPacket
+          temp_usb_pkt.usb_specific_feature();
+        end
+        $display("--------------------");
+      end
+    end
+
+    // Example without virtual method (if print was not virtual)
+    // If print() were not virtual, generic_pkt.print() would always be called.
+    // pkt_array[1].print(); // Would call Packet::print(), not EthPacket::print()
+  end
+endmodule
+```
+
+## UVM Context
+
+These OOP concepts are fundamental to the Universal Verification Methodology (UVM):
+
+*   **Inheritance:** All UVM components (`uvm_driver`, `uvm_monitor`, etc.) and objects (`uvm_sequence_item`, etc.) are derived from base classes like `uvm_component` and `uvm_object`. Users create their specific components by extending these UVM base classes.
+*   **Polymorphism & Virtual Methods:** The UVM factory relies heavily on polymorphism and virtual methods. When you use the factory to create components or override types (`set_type_override_by_name` or `set_type_override_by_type`), you are leveraging the ability of base class handles (e.g., `uvm_component`) to hold derived class objects. UVM's phasing methods (e.g., `build_phase`, `run_phase`) are virtual. This ensures that when the UVM framework calls `comp.run_phase()`, it executes the specific `run_phase` implementation of the component `comp`, not just the base `uvm_component::run_phase`. This allows for test-specific behavior and the construction of layered, configurable testbench environments.
+
+Mastering inheritance, polymorphism, and virtual methods in SystemVerilog is essential for effectively using and customizing UVM for complex verification tasks.

--- a/sv-uvm-guide/content/curriculum/sv-foundations/data-types/literals-and-basic-types.mdx
+++ b/sv-uvm-guide/content/curriculum/sv-foundations/data-types/literals-and-basic-types.mdx
@@ -1,0 +1,102 @@
+---
+id: 'sv-foundations-data-types-literals'
+title: 'Literals and Basic Types'
+---
+
+In SystemVerilog, literals are used to represent constant values. Understanding how to define and use them correctly is fundamental for both design and verification. Basic data types form the building blocks for representing signals and storage elements.
+
+## Theory: Number Literals and Basic Integer Types
+
+(Reference: IEEE 1800-2017 Standard, Clause 5: Data Types - Literals)
+
+### Number Literals
+
+SystemVerilog supports various ways to define numeric literals:
+
+1.  **Unsized Literals:** These are simple decimal numbers. The simulator or synthesis tool infers their size, typically defaulting to 32 bits.
+    *   Example: `123`, `'b101`, `'hFF` (Note: base specifier without size implies unsized, but its usage is less common for unsized than simply `123`).
+
+2.  **Sized Literals:** These explicitly define the number of bits and the base. The format is `<size>'<base><value>`.
+    *   `<size>`: A decimal number specifying the number of bits.
+    *   `<base>`: A single character indicating the base:
+        *   `'d` or `'D`: Decimal
+        *   `'h` or `'H`: Hexadecimal
+        *   `'b` or `'B`: Binary
+        *   `'o` or `'O`: Octal
+    *   `<value>`: The number in the specified base. Underscores (`_`) can be used for readability and are ignored. `x` or `X` represents an unknown value, and `z` or `Z` represents a high-impedance value.
+
+    *   Examples:
+        *   `8'd123` (8-bit decimal 123)
+        *   `16'hFACE` (16-bit hexadecimal FACE)
+        *   `4'b1010` (4-bit binary 1010)
+        *   `12'o777` (12-bit octal 777)
+        *   `8'b1100_0011` (Underscore for readability)
+        *   `4'b101x` (4-bit binary with LSB unknown)
+
+### Basic Integer Types
+
+SystemVerilog provides several built-in integer types:
+
+1.  **`integer`**: A 4-state signed variable, traditionally 32 bits wide (implementation-dependent, but commonly 32). It can hold values `0`, `1`, `X` (unknown), and `Z` (high-impedance).
+2.  **`time`**: A 4-state unsigned variable, typically 64 bits wide, used for storing simulation time. Accessed with the `$time` system function.
+3.  **`real`**: A variable that stores floating-point numbers (double-precision by default). This is primarily a simulation construct and is not synthesizable into hardware directly.
+4.  **`shortint`**: A 2-state signed 16-bit integer.
+5.  **`int`**: A 2-state signed 32-bit integer.
+6.  **`longint`**: A 2-state signed 64-bit integer.
+7.  **`byte`**: A 2-state signed 8-bit integer.
+8.  **`bit`**: A 2-state unsigned single-bit data type. Can be used to declare vectors, e.g., `bit [7:0] my_2state_byte;`. 2-state types (like `bit`, `int`) are generally more performant in simulation and can be more memory efficient than 4-state types when `X` and `Z` are not needed.
+
+(The types `logic`, `reg`, `wire` will be discussed in detail in the next section as they relate to nets and variables and 4-state values.)
+
+## Example
+
+Here's a `CodeBlock` demonstrating declarations and assignments of different literals and basic integer types:
+
+```systemverilog
+module literal_example;
+
+  // Unsized decimal literal
+  integer my_int_unsized = 12345;
+
+  // Sized literals
+  logic [7:0]  my_byte_bin    = 8'b0101_1010; // 8-bit binary
+  logic [15:0] my_word_hex    = 16'hCAFE;    // 16-bit hexadecimal
+  integer      my_int_sized   = 32'd100;     // 32-bit decimal
+  logic [3:0]  my_nibble_oct  = 4'o12;       // 4-bit octal (equivalent to 4'b1010)
+  logic [3:0]  unknown_val    = 4'b1xx0;     // Contains unknown bits
+
+  // Basic integer types
+  integer      count          = 0;
+  time         current_sim_time;
+  real         voltage_level  = 1.25;
+  int          fast_counter   = -5; // 2-state signed 32-bit
+  bit  [7:0]   flags          = 8'b1100_0000; // 2-state 8-bit vector
+
+  initial begin
+    current_sim_time = $time;
+    $display("Time: %0t, Unsized Int: %d, Byte: %b, Word: %h", current_sim_time, my_int_unsized, my_byte_bin, my_word_hex);
+    $display("Sized Int: %d, Nibble (oct): %o, Unknown: %b", my_int_sized, my_nibble_oct, unknown_val);
+    $display("Count: %d, Voltage: %f, Fast Counter: %d, Flags: %b", count, voltage_level, fast_counter, flags);
+
+    // Example of potential truncation with unsized literals if not careful
+    logic [3:0] small_vec;
+    small_vec = 'hF2; // Unsized hex literal 'hF2 (242 decimal) will be truncated to 4 bits
+    $display("Truncated small_vec from 'hF2: %h (binary %b)", small_vec, small_vec); // Will display 'h2 (binary 0010)
+
+    // Using sized literal prevents this
+    small_vec = 4'h2;
+    $display("Correct small_vec with 4'h2: %h (binary %b)", small_vec, small_vec); // Will display 'h2 (binary 0010)
+
+  end
+
+endmodule
+```
+
+## Best Practices
+
+*   **Always Use Sized Literals for Assignments:** When assigning values to signals or variables, especially those with a defined bit-width, always use sized literals (e.g., `8'hFA` instead of `'hFA`). This avoids ambiguity, prevents accidental truncation or unexpected extension, and makes the code clearer about intent.
+*   **Clarity with Base Specifiers:** While `'d` is often optional for decimal numbers, explicitly using base specifiers (`'b`, `'h`, `'o`) improves code readability, especially for non-decimal values.
+*   **Use Underscores for Readability:** For long bit strings or hex numbers, use underscores to group digits (e.g., `32'hDEAD_BEEF`, `16'b1111_0000_1010_0101`).
+*   **Understand 2-state vs. 4-state:** Choose 2-state types (`bit`, `int`, etc.) when you are certain that `X` (unknown) and `Z` (high-impedance) values are not required for the logic being modeled. This can lead to performance improvements in simulation. For RTL design that interfaces with other blocks or models real hardware, 4-state types (`logic`, `integer`, etc.) are generally safer to correctly model unknown or uninitialized states.
+
+By adhering to these practices, you can write more robust, readable, and maintainable SystemVerilog code.

--- a/sv-uvm-guide/content/curriculum/sv-foundations/data-types/nets-and-variables-logic-vs-wire.mdx
+++ b/sv-uvm-guide/content/curriculum/sv-foundations/data-types/nets-and-variables-logic-vs-wire.mdx
@@ -1,0 +1,110 @@
+---
+id: 'sv-foundations-data-types-nets-variables'
+title: 'Nets and Variables: logic vs. wire'
+---
+
+Understanding the distinction between nets and variables is crucial in SystemVerilog, as it reflects the underlying hardware concepts of connections versus storage. The introduction of the `logic` data type in SystemVerilog offered a more unified approach compared to traditional Verilog's `wire` and `reg`.
+
+## Theory: Nets vs. Variables
+
+(Reference: IEEE 1800-2017 Standard, Clause 6: Data Types - Nets and Variables)
+
+### Nets
+
+*   **Concept:** Nets represent physical connections between hardware elements, like wires in a circuit. They do not store values themselves but reflect the value of their drivers.
+*   **Driving:** A net must be continuously driven by something, such as the output of a primitive (e.g., `and` gate), a continuous `assign` statement, or from a module's port. If a net has no driver, its value is typically high-impedance (`Z`), unless it has a resolution function (e.g., `trireg` for charge storage, or `wand`/`wor` for wired-AND/OR logic).
+*   **`wire`:** The most common net type. It's a 4-state data type (`0`, `1`, `X`, `Z`). Other net types include `wand`, `wor`, `tri`, `tri0`, `tri1`, `triand`, `trior`, `trireg`, `supply0`, `supply1`.
+*   **Usage:** Primarily for connecting module instances, continuous assignments, and modeling physical wiring.
+
+### Variables
+
+*   **Concept:** Variables store values, similar to variables in software programming languages. They retain their value until explicitly changed by an assignment.
+*   **Driving:** Variables are assigned values within procedural blocks (e.g., `initial`, `always`, `always_ff`, `always_comb`, `always_latch`), class methods, or functions/tasks.
+*   **`reg` (Verilog legacy):** In traditional Verilog, `reg` was the primary keyword for declaring variables that could be assigned in procedural blocks. It's a 4-state data type. The name `reg` can be misleading, as it doesn't always imply a hardware register (e.g., it could model temporary storage or combinational logic outputs within an `always_comb`).
+*   **`logic` (SystemVerilog):** SystemVerilog introduced `logic` as a more versatile 4-state data type.
+    *   It can be used just like `reg` for procedural assignments.
+    *   Crucially, `logic` can also be continuously assigned, just like a `wire`. This means `logic` can be driven by one continuous assignment or by multiple procedural assignments (though not simultaneously by both in a conflicting manner).
+    *   It can also be used for module ports, simplifying declarations.
+*   **Other Variable Types:** `integer`, `time`, `real`, `byte`, `shortint`, `int`, `longint`, `bit` are also variable types.
+
+### `logic` vs. `wire`
+
+The key distinction to remember:
+
+*   **`wire`**: Must be continuously driven. Cannot be assigned to in a procedural block (e.g., `always @(posedge clk) wire_signal <= ...;` is illegal).
+*   **`logic`**: Can be assigned in procedural blocks. Can ALSO be driven by a single continuous assignment.
+
+Because of its flexibility, `logic` has become the preferred general-purpose 4-state data type in modern SystemVerilog for both RTL design and testbenches.
+
+## Example
+
+This example demonstrates a `wire` being driven by a continuous assignment and `logic` variables being assigned within `always_comb` (for combinational logic) and `always_ff` (for sequential logic) blocks.
+
+```systemverilog
+module nets_vs_variables (
+  input  logic clk,
+  input  logic rst_n,
+  input  logic a,
+  input  logic b,
+  output logic y_comb_logic, // Output driven by logic
+  output wire  y_wire        // Output driven by wire
+);
+
+  // 'data_bus' is a wire, driven by a continuous assignment
+  // It represents a connection.
+  wire [7:0] data_bus;
+  assign data_bus = {a, b, a, b, a, b, a, b}; // Continuously driven
+
+  // 'y_wire' is an output wire, also driven by a continuous assignment
+  assign y_wire = data_bus[0] & data_bus[1];
+
+  // 'temp_logic' is a logic type used as a variable within a procedural block
+  logic temp_logic;
+  always_comb begin
+    temp_logic = a ^ b; // Assigned like a variable
+  end
+
+  // 'y_comb_logic' is an output logic, driven by a procedural block
+  // It behaves like a variable whose value is determined by the combinational logic.
+  always_comb begin
+    if (a && b) begin
+      y_comb_logic = 1'b1;
+    end else begin
+      y_comb_logic = temp_logic;
+    end
+  end
+
+  // 'counter' is a logic type used to model a sequential register
+  logic [3:0] counter;
+  always_ff @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      counter <= 4'b0;
+    end else begin
+      counter <= counter + 1;
+    end
+  end
+
+  initial begin
+    #1 $display("Initial: a=%b, b=%b, data_bus=%h, y_wire=%b, temp_logic=%b, y_comb_logic=%b, counter=%d",
+                a, b, data_bus, y_wire, temp_logic, y_comb_logic, counter);
+    #100; // Let simulation run for a bit
+    $display("After 100ns: a=%b, b=%b, data_bus=%h, y_wire=%b, temp_logic=%b, y_comb_logic=%b, counter=%d",
+                a, b, data_bus, y_wire, temp_logic, y_comb_logic, counter);
+  end
+
+endmodule
+```
+
+## Best Practices
+
+When deciding between `logic` and `wire` (or the older `reg`):
+
+1.  **Prefer `logic` for general use:** For new SystemVerilog code, `logic` is generally the recommended 4-state type for variables and signals unless a specific net type (like `tri` for tri-state buses or `wand` for wired-AND logic) is explicitly needed.
+    *   **Verification Academy Recommendation:** Many industry guidelines, including those often cited by resources like Siemens Verification Academy or Doulos, promote using `logic` over `reg`. For example, a common guideline is: *"Use `logic` for all state-holding variables and outputs of procedural blocks. Use `wire` only for signals that require multiple drivers (e.g., unresolved `assign` statements from different modules to the same wire, which is generally poor practice anyway) or specific net types like `tri`."*
+2.  **Use `wire` for multiple continuous drivers:** If you need to model situations with multiple continuous drivers (e.g., a tri-state bus where different components can drive the bus), you must use a net type like `wire` or `tri`. A `logic` variable cannot have multiple continuous assignments or procedural drivers driving it simultaneously.
+3.  **Clarity of Intent:**
+    *   If a signal is purely a connection point and is always driven by a single continuous `assign` statement or by a primitive output, `wire` can still be used to clearly indicate its nature as a connection. However, `logic` would also work here.
+    *   If a signal holds state or is assigned within an `always` block, `logic` (or `reg` in older Verilog code) is appropriate.
+4.  **Port Declarations:** `logic` can be used for module ports of any direction (`input`, `output`, `inout`). This simplifies port declarations compared to Verilog, where an `output` assigned in a procedural block had to be declared as `output reg`. With SystemVerilog, it's just `output logic`.
+
+By understanding these distinctions and following modern best practices, your SystemVerilog code will be more readable, maintainable, and less prone to errors.

--- a/sv-uvm-guide/content/curriculum/sv-foundations/introduction.mdx
+++ b/sv-uvm-guide/content/curriculum/sv-foundations/introduction.mdx
@@ -1,0 +1,22 @@
+---
+id: 'sv-foundations-introduction'
+title: 'Introduction to SystemVerilog Foundations'
+---
+
+## Introduction to SystemVerilog
+
+SystemVerilog, standardized as IEEE 1800, is a powerful hardware description and verification language (HDVL). It evolved as a successor to Verilog (IEEE 1364), significantly extending its capabilities by integrating features for both complex hardware design and sophisticated, assertion-based verification.
+
+Historically, Verilog was primarily used for hardware design (RTL - Register Transfer Level). As design complexity grew, the need for more robust verification methodologies became critical. Standalone Hardware Verification Languages (HVLs) like Vera and e emerged. SystemVerilog aimed to unify these domains, providing a single language that could handle large-scale design, testbench development, assertions, and formal verification. It incorporates object-oriented programming, enhanced data types, and dedicated constructs for verification, making it the industry standard for modern chip design and verification workflows.
+
+## Key Goals of this Module (SystemVerilog Foundations)
+
+This module will lay the groundwork for understanding and utilizing SystemVerilog effectively. By the end of this module, you will:
+
+*   **Understand Core Data Types:** Learn about SystemVerilog's rich set of data types, including `logic`, `bit`, `integer`, arrays (fixed, dynamic, associative, queues), and structures. Grasp the difference between nets (e.g., `wire`) and variables (e.g., `logic`, `reg`).
+*   **Master Procedural Blocks:** Become proficient with procedural blocks like `initial`, `always`, `always_comb`, `always_ff`, and `always_latch`, understanding their execution semantics and use cases in modeling hardware behavior and testbench components.
+*   **Develop Basic Testbench Constructs:** Learn to build fundamental testbench elements, including module instantiation, clock generation, applying stimulus, and observing outputs. Understand the role of program blocks and clocking blocks in creating race-free testbenches.
+*   **Grasp Interface Concepts:** Be introduced to SystemVerilog interfaces for bundling signals and simplifying module connections, including the use of modports.
+*   **Write Basic Assertions:** Get a first look at SystemVerilog Assertions (SVA) for specifying design properties and checks.
+
+This foundational knowledge is crucial before diving into more advanced SystemVerilog features or the Universal Verification Methodology (UVM).

--- a/sv-uvm-guide/content/curriculum/uvm-core/base-class-library/uvm-object-vs-uvm-component.mdx
+++ b/sv-uvm-guide/content/curriculum/uvm-core/base-class-library/uvm-object-vs-uvm-component.mdx
@@ -1,0 +1,129 @@
+---
+id: 'uvm-core-bcl-object-vs-component'
+title: 'uvm_object vs. uvm_component'
+---
+
+In the Universal Verification Methodology (UVM), all classes are ultimately derived from `uvm_void`, but the two most fundamental base classes that users interact with are `uvm_object` and `uvm_component`. Understanding their distinct roles and characteristics is essential for building UVM testbenches.
+
+## Theory: The Fundamental Distinction
+
+(Reference: Accellera UVM 1.2 Class Reference Manual)
+
+The primary difference lies in their purpose and lifecycle within the UVM testbench environment:
+
+### `uvm_component`
+
+*   **Concept:** A `uvm_component` represents a static, structural element of the testbench that has a persistent place in the testbench hierarchy. Think of them as the building blocks of your environment.
+*   **Hierarchy:** Components have a parent-child relationship, forming a tree-like structure. Each component (except the top-level `uvm_root`) has a unique hierarchical path name.
+*   **Phasing:** Components participate in the UVM phasing mechanism. This means they progress through a series of predefined phases (e.g., `build_phase`, `connect_phase`, `run_phase`, `report_phase`), allowing for orderly construction, connection, execution, and cleanup of the testbench.
+*   **Instantiation:** Typically created using the `create()` method, often within the `build_phase` of their parent component. The factory pattern is used for their construction, enabling overrides.
+*   **Lifetime:** Generally exist for the entire duration of the simulation once created.
+*   **Examples:** `uvm_driver`, `uvm_monitor`, `uvm_sequencer`, `uvm_agent`, `uvm_scoreboard`, `uvm_env`, `uvm_test`.
+
+### `uvm_object`
+
+*   **Concept:** A `uvm_object` represents transient data or information that is passed around within the testbench. They do not have a fixed place in the testbench hierarchy.
+*   **Hierarchy:** Objects do not have a parent in the UVM component hierarchy. They are not part of the static structure.
+*   **Phasing:** Objects are not directly involved in the UVM phasing mechanism. Their creation and usage are typically managed by components within their respective phases.
+*   **Instantiation:** Typically created using their constructor (`new()`), often within sequences or by components when they need to generate or process data. While they can be registered with the factory (and often are, e.g., sequence items), their creation doesn't automatically tie them into the component hierarchy or phasing.
+*   **Lifetime:** Can be short-lived (e.g., a transaction processed and then discarded) or exist for longer durations if held by a component (e.g., a configuration object).
+*   **Examples:** `uvm_sequence_item` (transactions), `uvm_config_object`, `uvm_reg_item`, `uvm_sequence` (though sequences have some special behaviors, they are fundamentally objects).
+
+## Key Differences Table
+
+| Feature                 | `uvm_component`                                     | `uvm_object`                                        |
+| :---------------------- | :-------------------------------------------------- | :-------------------------------------------------- |
+| **Hierarchy**           | Yes (has a parent, part of testbench structure)     | No (not part of component hierarchy)                |
+| **Phasing**             | Yes (e.g., `build_phase`, `run_phase`, etc.)        | No (does not directly participate in phases)        |
+| **Instantiation**       | `create()` method (factory, typically in `build_phase`) | `new()` constructor (often in sequences, components) |
+| **Purpose**             | Structural, static elements of the testbench        | Transient data packets, configuration, sequences    |
+| **Hierarchical Path**   | Yes (e.g., `uvm_test_top.env.agent.driver`)         | No                                                  |
+| **TLM Ports/Exports/Imps** | Yes (used for communication between components)     | No (objects are data, they don't have TLM ports)    |
+| **Configuration**       | Configured via `uvm_config_db` or direct assignment | Can be configuration itself or carry configuration  |
+
+## Example Code Snippets
+
+Here are basic class definitions to illustrate the different base classes:
+
+### `my_driver` (extends `uvm_driver`, which extends `uvm_component`)
+
+```systemverilog
+// my_driver.sv
+import uvm_pkg::*;
+`include "uvm_macros.svh"
+
+// Forward declaration of the sequence item type
+class my_transaction;
+
+class my_driver extends uvm_driver #(my_transaction); // my_transaction is the type of item it will drive
+
+  `uvm_component_utils(my_driver)
+
+  // Constructor
+  function new(string name = "my_driver", uvm_component parent = null);
+    super.new(name, parent);
+  endfunction
+
+  // Standard UVM phases
+  virtual function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    // Component-specific build activities, e.g., getting configuration
+    $display("%s: In build_phase", get_full_name());
+  endfunction
+
+  virtual task run_phase(uvm_phase phase);
+    my_transaction req;
+    // Main driving loop
+    forever begin
+      seq_item_port.get_next_item(req); // Get transaction from sequencer
+      $display("%s: Driving transaction: %s", get_full_name(), req.convert2string());
+      // Code to drive signals based on 'req' would go here
+      #10; // Simulate time to drive
+      seq_item_port.item_done(); // Indicate transaction completion
+    end
+  endtask
+
+endclass
+```
+
+### `my_transaction` (extends `uvm_sequence_item`, which extends `uvm_object`)
+
+```systemverilog
+// my_transaction.sv
+import uvm_pkg::*;
+`include "uvm_macros.svh"
+
+class my_transaction extends uvm_sequence_item;
+
+  // Data fields for the transaction
+  rand bit [7:0] addr;
+  rand bit [31:0] data;
+  rand bit is_write;
+
+  // Constraints for randomization (optional)
+  constraint c_addr_range { addr < 8'hF0; }
+
+  `uvm_object_utils_begin(my_transaction)
+    `uvm_field_int(addr, UVM_ALL_ON)
+    `uvm_field_int(data, UVM_ALL_ON)
+    `uvm_field_int(is_write, UVM_ALL_ON)
+  `uvm_object_utils_end
+
+  // Constructor
+  function new(string name = "my_transaction");
+    super.new(name);
+  endfunction
+
+  // Optional: custom methods like convert2string if not using field macros for it fully
+  // virtual function string convert2string();
+  //   return $sformatf("Addr:0x%0h Data:0x%0h Write:%b", addr, data, is_write);
+  // endfunction
+
+endclass
+```
+
+In these examples:
+*   `my_driver` is a `uvm_component` that will exist in the testbench hierarchy and execute its `run_phase` to drive signals.
+*   `my_transaction` is a `uvm_object` that represents a piece of data (an operation to be performed on the DUT) that will be created, randomized, and passed from a sequencer to the `my_driver`.
+
+Understanding this separation is key to structuring UVM environments correctly. Components form the static framework, while objects flow through this framework as dynamic data or stimulus.

--- a/sv-uvm-guide/content/curriculum/uvm-core/phasing-and-synchronization/the-uvm-phases-in-detail.mdx
+++ b/sv-uvm-guide/content/curriculum/uvm-core/phasing-and-synchronization/the-uvm-phases-in-detail.mdx
@@ -1,0 +1,301 @@
+---
+id: 'uvm-core-phasing-detail'
+title: 'The UVM Phases in Detail'
+---
+
+The UVM phasing mechanism provides a structured approach to managing the lifecycle of a verification environment. It ensures that components are built, connected, and data is processed in an orderly and synchronized manner. Phases are methods that are automatically called by the UVM framework on all `uvm_component` instances.
+
+(References: Accellera UVM 1.2 User Guide, UVM 1.2 Class Reference, Doulos UVM Golden Reference/Tutorials)
+
+## Overview of Phasing
+
+UVM defines a series of standard phases, grouped into three main categories:
+
+1.  **Build Phases:** These execute top-down in the UVM hierarchy. They are primarily used for constructing and configuring the testbench component hierarchy.
+2.  **Run-time Phases:** These execute in parallel (quasi-statically scheduled tasks) after the build phases complete. This is where the actual simulation time passes and stimulus is applied to the DUT.
+3.  **Clean-up Phases:** These execute bottom-up in the UVM hierarchy. They are used for extracting information, checking results, and reporting simulation status.
+
+All phase methods are `virtual` functions or tasks within `uvm_component`, allowing derived components to override them and add specific behavior. Each phase method receives a `uvm_phase` object as an argument, which provides context about the current phase and allows for operations like raising/dropping objections.
+
+## Diagram: UVM Phase Execution Order
+
+Here's a simplified textual representation of the main common phases and their execution order:
+
+```mermaid
+graph TD
+    A[build_phase (top-down)] --> B(connect_phase (top-down))
+    B --> C(end_of_elaboration_phase (top-down))
+    C --> D(start_of_simulation_phase (top-down))
+    D --> E{run_phase (parallel tasks)}
+    E --> F(extract_phase (bottom-up))
+    F --> G(check_phase (bottom-up))
+    G --> H(report_phase (bottom-up))
+    H --> I(final_phase (top-down))
+
+    subgraph Build Phases
+        A
+        B
+        C
+        D
+    end
+
+    subgraph Run-Time Phase Group
+        E
+    end
+
+    subgraph Clean-up Phases
+        F
+        G
+        H
+    end
+
+    %% Note: Run-time phases like pre_reset, reset, etc. execute within or around the run_phase.
+    %% For simplicity, they are grouped under run_phase here.
+```
+
+*(This Mermaid diagram illustrates the general flow. The `run_phase` itself is a task-based phase, and other task-based "run-time" sub-phases like `reset_phase`, `main_phase`, etc., execute in a specific order if explicitly used and objections are managed.)*
+
+## Detailed Phase Descriptions and Code Snippets
+
+### 1. Build Phases (Function-based, execute top-down)
+
+These phases are used to construct the testbench hierarchy and make connections. They execute in zero simulation time.
+
+#### a. `build_phase(uvm_phase phase)`
+*   **Purpose:** The primary phase for constructing child components using the factory (`create()`) and configuring them (e.g., using `uvm_config_db::set()` and `uvm_config_db::get()`).
+*   **Execution Order:** Top-down. A parent's `build_phase` completes before its children's `build_phase` methods are called.
+```systemverilog
+class my_env extends uvm_env;
+  `uvm_component_utils(my_env)
+  my_agent m_agent; // Child component handle
+
+  function new(string name = "my_env", uvm_component parent = null);
+    super.new(name, parent);
+  endfunction
+
+  virtual function void build_phase(uvm_phase phase);
+    super.build_phase(phase); // Important to call super
+    $display("%s: In build_phase", get_full_name());
+    // Create child component
+    m_agent = my_agent::type_id::create("m_agent", this);
+    // Set configuration for child or its descendants
+    uvm_config_db#(int)::set(this, "m_agent.m_driver", "num_retries", 3);
+  endfunction
+endclass
+```
+
+#### b. `connect_phase(uvm_phase phase)`
+*   **Purpose:** Used to make TLM (Transaction-Level Modeling) connections between components (e.g., connecting a monitor's analysis port to a scoreboard's analysis export). Also used for connecting other types of references between components.
+*   **Execution Order:** Top-down.
+```systemverilog
+class my_agent extends uvm_agent;
+  `uvm_component_utils(my_agent)
+  my_monitor m_monitor;
+  uvm_analysis_port #(my_transaction) ap_to_scoreboard; // Port on the agent
+
+  // ... constructor, build_phase to create m_monitor ...
+  function new(string name = "my_agent", uvm_component parent = null);
+    super.new(name, parent);
+    ap_to_scoreboard = new("ap_to_scoreboard", this);
+  endfunction
+
+  virtual function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    m_monitor = my_monitor::type_id::create("m_monitor", this);
+  endfunction
+
+  virtual function void connect_phase(uvm_phase phase);
+    super.connect_phase(phase);
+    $display("%s: In connect_phase", get_full_name());
+    if (is_active == UVM_ACTIVE) begin
+      // Driver's seq_item_export connected to Sequencer's seq_item_port (often done by uvm_agent)
+    end
+    // Connect monitor's analysis port to the agent's analysis port
+    m_monitor.ap.connect(this.ap_to_scoreboard);
+  endfunction
+endclass
+```
+
+#### c. `end_of_elaboration_phase(uvm_phase phase)`
+*   **Purpose:** The last chance to make any final adjustments to the component hierarchy or configuration before simulation starts. Useful for displaying topology information or performing checks that require the entire hierarchy to be built and connected.
+*   **Execution Order:** Top-down.
+```systemverilog
+class my_scoreboard extends uvm_scoreboard;
+  `uvm_component_utils(my_scoreboard)
+  // ... constructor ...
+  function new(string name = "my_scoreboard", uvm_component parent = null);
+    super.new(name, parent);
+  endfunction
+
+  virtual function void end_of_elaboration_phase(uvm_phase phase);
+    super.end_of_elaboration_phase(phase);
+    $display("%s: In end_of_elaboration_phase. Testbench construction complete.", get_full_name());
+    // Example: Print configuration or check for expected connections
+  endfunction
+endclass
+```
+
+#### d. `start_of_simulation_phase(uvm_phase phase)`
+*   **Purpose:** Called just before time-consuming simulation phases begin. Used for tasks like initializing component state that depends on the final elaborated design, displaying banner information, or setting up debug features.
+*   **Execution Order:** Top-down.
+```systemverilog
+class base_test extends uvm_test;
+  `uvm_component_utils(base_test)
+  // ... constructor ...
+  function new(string name = "base_test", uvm_component parent = null);
+    super.new(name, parent);
+  endfunction
+
+  virtual function void start_of_simulation_phase(uvm_phase phase);
+    super.start_of_simulation_phase(phase);
+    $display("=====================================================");
+    $display("Starting Test: %s", get_type_name());
+    $display("UVM Seed: %0d", uvm_pkg::uvm_get_to_pkg_scope().get_uvm_seeder().get_seed());
+    $display("=====================================================");
+    // Set a drain time for the run_phase if not using specific run-time sub-phases
+    phase.phase_done.set_drain_time(this, 200ns);
+  endfunction
+endclass
+```
+
+### 2. Run-Time Phases (Task-based, execute in parallel)
+
+These phases are where simulation time advances. They are task-based, allowing them to consume simulation time. The `run_phase` is the main one, but UVM provides a set of predefined run-time phases that execute in sequence if used.
+
+#### `run_phase(uvm_phase phase)`
+*   **Purpose:** The primary phase for stimulus generation, driving DUT signals, monitoring DUT activity, and checking behavior. This phase (and other run-time task phases) proceeds only if objections are raised. When all objections are dropped, the phase ends.
+*   **Execution Order:** All components' `run_phase` tasks start effectively in parallel. Their execution is coordinated by stimulus generation (sequences) and UVM's objection mechanism.
+```systemverilog
+class my_driver extends uvm_driver #(my_transaction);
+  // ... utils, new ...
+  `uvm_component_utils(my_driver)
+  function new(string name = "my_driver", uvm_component parent = null);
+    super.new(name,parent);
+  endfunction
+
+  virtual task run_phase(uvm_phase phase);
+    // Raise an objection to keep the phase running while this driver is active
+    // phase.raise_objection(this, "Driver is active");
+    // No explicit objection needed here if sequence raises it
+
+    forever begin
+      my_transaction tr;
+      seq_item_port.get_next_item(tr); // Get transaction from sequencer
+      $display("[%0t] %s: Received transaction: %s", $time, get_full_name(), tr.convert2string());
+      // Actual signal driving logic would be here
+      # (tr.delay)ns; // Consume time based on transaction
+      $display("[%0t] %s: Finished driving transaction", $time, get_full_name());
+      seq_item_port.item_done();
+    end
+    // phase.drop_objection(this, "Driver finished its work");
+  endtask
+endclass
+
+// In a sequence:
+class my_sequence extends uvm_sequence #(my_transaction);
+  // ... utils, new ...
+  `uvm_object_utils(my_sequence)
+  function new(string name="my_sequence");
+    super.new(name);
+  endfunction
+
+  virtual task body();
+    // Raise objection at the start of the sequence if it's controlling the test duration
+    if (starting_phase != null) starting_phase.raise_objection(this, "Sequence started");
+
+    // Create and send transactions
+    repeat(5) begin
+      my_transaction tr = my_transaction::type_id::create("tr");
+      start_item(tr);
+      assert(tr.randomize());
+      // tr.delay = $urandom_range(5, 20);
+      finish_item(tr);
+      #1ns; // Small delay between transactions
+    end
+
+    if (starting_phase != null) starting_phase.drop_objection(this, "Sequence completed");
+  endtask
+endclass
+```
+*   **Other Run-Time Phases:** UVM also defines finer-grained run-time phases like `pre_reset_phase`, `reset_phase`, `post_reset_phase`, `pre_configure_phase`, `configure_phase`, `post_configure_phase`, `pre_main_phase`, `main_phase`, `post_main_phase`, `pre_shutdown_phase`, `shutdown_phase`, `post_shutdown_phase`. These allow for more structured control over different stages of a test (e.g., applying resets, configuring DUT registers, running main stimulus). They execute in a specific order if objections are raised for them. If these are used, the main `run_phase` typically might not be directly used, or it runs in parallel with them.
+
+### 3. Clean-up Phases (Function-based, execute bottom-up)
+
+These phases run after all time-consuming run phases have completed. They are used to collect final results, perform checks, and generate reports.
+
+#### a. `extract_phase(uvm_phase phase)`
+*   **Purpose:** Used to extract data from various parts of the testbench (e.g., scoreboard, coverage collectors, monitors) for final processing and checking.
+*   **Execution Order:** Bottom-up. A child's `extract_phase` completes before its parent's.
+```systemverilog
+class my_scoreboard extends uvm_scoreboard;
+  // ... utils, new, write method ...
+  `uvm_component_utils(my_scoreboard)
+  function new(string name = "my_scoreboard", uvm_component parent=null);
+    super.new(name,parent);
+  endfunction
+
+  int actual_packets_received = 0;
+  // write method called by monitor to push transactions
+
+  virtual function void extract_phase(uvm_phase phase);
+    super.extract_phase(phase);
+    $display("%s: In extract_phase. Total packets received: %0d", get_full_name(), actual_packets_received);
+    // Further processing of collected data can happen here
+  endfunction
+endclass
+```
+
+#### b. `check_phase(uvm_phase phase)`
+*   **Purpose:** Used to perform final checks on the extracted data to determine if the test passed or failed. For example, comparing expected results with actual results.
+*   **Execution Order:** Bottom-up.
+```systemverilog
+// Continuing my_scoreboard from above
+  int expected_packets = 100; // This might be set by config_db or test
+
+  virtual function void check_phase(uvm_phase phase);
+    super.check_phase(phase);
+    $display("%s: In check_phase.", get_full_name());
+    if (actual_packets_received == expected_packets) begin
+      `uvm_info("SCOREBOARD_PASS", $sformatf("All %0d packets received correctly.", expected_packets), UVM_LOW)
+    end else begin
+      `uvm_error("SCOREBOARD_FAIL", $sformatf("Mismatch! Expected %0d packets, got %0d.", expected_packets, actual_packets_received))
+    end
+  endfunction
+```
+
+#### c. `report_phase(uvm_phase phase)`
+*   **Purpose:** Used to generate and display final simulation reports, summaries of test results, coverage information, etc.
+*   **Execution Order:** Bottom-up.
+```systemverilog
+// Continuing my_scoreboard from above
+  virtual function void report_phase(uvm_phase phase);
+    super.report_phase(phase);
+    `uvm_info(get_full_name(), $sformatf("Final Report: Processed %0d packets. Expected %0d.", actual_packets_received, expected_packets), UVM_NONE)
+    // UVM automatically calls uvm_report_object.report_summaries() at the end of this phase
+  endfunction
+endclass
+```
+
+#### d. `final_phase(uvm_phase phase)`
+*   **Purpose:** The very last phase. Used for any final cleanup actions, closing files, or terminating external processes.
+*   **Execution Order:** Top-down. (Note: This is an exception to the bottom-up nature of other cleanup phases).
+```systemverilog
+class base_test extends uvm_test;
+  // ... utils, new ...
+  `uvm_component_utils(base_test)
+  function new(string name = "base_test", uvm_component parent=null);
+    super.new(name,parent);
+  endfunction
+
+  virtual function void final_phase(uvm_phase phase);
+    super.final_phase(phase);
+    $display("=====================================================");
+    $display("Test %s finished. Simulation Time: %0t ns", get_type_name(), $time);
+    $display("UVM Verbosity Level: %s", uvm_root::get().get_report_verbosity_level_hier() );
+    $display("=====================================================");
+    // Any final actions like closing log files
+  endfunction
+endclass
+```
+
+Understanding and correctly utilizing these phases is key to building robust, reusable, and maintainable UVM verification environments. Each phase provides a specific context and timing for different testbench operations.

--- a/sv-uvm-guide/src/app/components/layout/Breadcrumbs.tsx
+++ b/sv-uvm-guide/src/app/components/layout/Breadcrumbs.tsx
@@ -1,0 +1,40 @@
+import Link from 'next/link';
+import type { CurriculumNode } from '@/lib/curriculum-data'; // Adjust path as needed
+
+interface BreadcrumbsProps {
+  nodes: CurriculumNode[];
+}
+
+const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ nodes }) => {
+  if (!nodes || nodes.length === 0) {
+    return null;
+  }
+
+  return (
+    <nav aria-label="Breadcrumb" className="mb-6 text-sm text-gray-400">
+      <ol className="list-none p-0 inline-flex space-x-2">
+        <li className="flex items-center">
+          <Link href="/curriculum" className="hover:text-accent">
+            Curriculum
+          </Link>
+        </li>
+        {nodes.map((node, index) => (
+          <li key={node.id} className="flex items-center">
+            <span className="mx-2">/</span>
+            {index === nodes.length - 1 ? (
+              <span className="text-primary-text font-semibold" aria-current="page">
+                {node.title}
+              </span>
+            ) : (
+              <Link href={node.path} className="hover:text-accent">
+                {node.title}
+              </Link>
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+};
+
+export default Breadcrumbs;

--- a/sv-uvm-guide/src/app/curriculum/[...slug]/page.tsx
+++ b/sv-uvm-guide/src/app/curriculum/[...slug]/page.tsx
@@ -1,0 +1,176 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { compileMDX } from 'next-mdx-remote/rsc';
+import grayMatter from 'gray-matter';
+import Link from 'next/link';
+
+import {
+  curriculumData,
+  getAllCurriculumNodes,
+  findNodeByPath,
+  getBreadcrumbs,
+  getNextPrevLessons,
+  type CurriculumNode,
+} from '@/lib/curriculum-data';
+import Breadcrumbs from '@/app/components/layout/Breadcrumbs';
+import Button from '@/app/components/ui/Button';
+import { CodeBlock } from '@/app/components/ui/CodeBlock'; // Assuming CodeBlock is suitable for MDX
+import { Card } from '@/app/components/ui/Card';
+
+
+// Define components to be used in MDX
+const mdxComponents = {
+  h1: (props: React.HTMLAttributes<HTMLHeadingElement>) => <h1 className="text-3xl font-bold my-4 text-primary-text" {...props} />,
+  h2: (props: React.HTMLAttributes<HTMLHeadingElement>) => <h2 className="text-2xl font-semibold my-3 text-primary-text" {...props} />,
+  h3: (props: React.HTMLAttributes<HTMLHeadingElement>) => <h3 className="text-xl font-semibold my-2 text-primary-text" {...props} />,
+  p: (props: React.HTMLAttributes<HTMLParagraphElement>) => <p className="my-4 leading-relaxed" {...props} />,
+  ul: (props: React.HTMLAttributes<HTMLUListElement>) => <ul className="list-disc list-inside my-4 pl-4" {...props} />,
+  ol: (props: React.HTMLAttributes<HTMLOListElement>) => <ol className="list-decimal list-inside my-4 pl-4" {...props} />,
+  li: (props: React.HTMLAttributes<HTMLLIElement>) => <li className="mb-2" {...props} />,
+  code: (props: React.HTMLAttributes<HTMLElement>) => {
+    // This handles inline code. For code blocks, we'll use the CodeBlock component via remark/rehype plugins or explicit use.
+    // If `rehype-pretty-code` is used as a plugin with `compileMDX`, it might transform ``` ``` blocks automatically.
+    // For this example, inline code gets basic styling.
+    return <code className="bg-gray-700 text-accent px-1 py-0.5 rounded text-sm font-mono" {...props} />;
+  },
+  // We can map actual ``` ``` language blocks to our CodeBlock component
+  // This is typically done via rehype plugins when processing MDX.
+  // For now, if MDX contains <CodeBlock code="..." language="...", this would work.
+  // Or, we can use a rehype plugin to transform fenced code blocks.
+  CodeBlock, // Makes <CodeBlock code="..." language=".." /> usable in MDX
+  Button,    // Makes <Button> usable in MDX if needed
+  Card,      // Makes <Card> usable in MDX
+};
+
+
+export async function generateStaticParams() {
+  const allNodes = getAllCurriculumNodes(curriculumData);
+  // Filter out parent nodes that have children, only generate pages for leaf nodes or nodes intended to have content
+  const contentPages = allNodes.filter(node => {
+    // Logic to determine if a node should have a page:
+    // 1. It's a leaf node (no children)
+    // 2. Or, it's a node that is explicitly planned to have content (e.g. introduction pages for sections)
+    // For this setup, we assume all defined paths in curriculumData might have a corresponding .mdx file.
+    // The prompt implies all nodes in curriculumData could be pages.
+    return true; // For now, assume all nodes can be pages.
+  });
+
+  return contentPages.map((node) => ({
+    slug: node.path.replace('/curriculum/', '').split('/'),
+  }));
+}
+
+async function getPageContent(slug: string[]) {
+  const currentPath = `/curriculum/${slug.join('/')}`;
+  const node = findNodeByPath(curriculumData, currentPath);
+
+  if (!node) {
+    return null;
+  }
+
+  const filePath = path.join(process.cwd(), 'content', 'curriculum', ...slug) + '.mdx';
+
+  try {
+    const rawContent = await fs.readFile(filePath, 'utf-8');
+    const { content, data: frontmatter } = grayMatter(rawContent);
+
+    const { content: compiledContent } = await compileMDX<{ title: string }>({
+      source: content,
+      components: mdxComponents,
+      options: {
+        parseFrontmatter: false, // Already parsed by gray-matter
+        mdxOptions: {
+          // remarkPlugins: [],
+          rehypePlugins: [
+            // Add rehypePrettyCode here if not handled by CodeBlock component directly for MDX fenced blocks
+            // Example: [rehypePrettyCode, { theme: 'github-dark' }]
+            // However, our CodeBlock component does its own rehype processing.
+            // For MDX fenced code blocks to automatically use it, a custom rehype plugin would be needed
+            // to replace `pre/code` elements with calls to our `CodeBlock` component.
+            // For simplicity, MDX files can explicitly use `<CodeBlock code="..." />`
+          ],
+        },
+      },
+    });
+
+    return { node, frontmatter, compiledContent };
+  } catch (error) {
+    console.error(`Error reading or compiling MDX for ${currentPath}:`, error);
+    // If file not found, it's okay, might be a category page without its own MDX
+    // but for this prompt, we expect MDX for each page.
+    return { node, frontmatter: { title: node.title }, compiledContent: <p>Content not found for this page.</p> };
+  }
+}
+
+export default async function CurriculumPage({ params }: { params: { slug: string[] } }) {
+  const data = await getPageContent(params.slug);
+
+  if (!data || !data.node) {
+    return <div className="container mx-auto px-4 py-8 text-red-500">Page not found.</div>;
+  }
+
+  const { node, frontmatter, compiledContent } = data;
+  const breadcrumbNodes = getBreadcrumbs(curriculumData, node.path);
+  const allNodesFlat = getAllCurriculumNodes(curriculumData);
+  const { prev, next } = getNextPrevLessons(allNodesFlat, node.path);
+
+  return (
+    <div className="container mx-auto px-4 py-8 text-primary-text">
+      <Breadcrumbs nodes={breadcrumbNodes} />
+      <article className="prose prose-invert max-w-none lg:prose-xl">
+        <h1 className="text-4xl font-bold mb-8 text-accent">{frontmatter.title || node.title}</h1>
+
+        {/* Render the compiled MDX content */}
+        {compiledContent}
+
+      </article>
+
+      <div className="mt-12 pt-8 border-t border-[rgba(100,255,218,0.2)]">
+        <h3 className="text-xl font-semibold mb-4">End-of-Lesson Actions</h3>
+        <div className="flex flex-col sm:flex-row space-y-4 sm:space-y-0 sm:space-x-4">
+          <Button variant="primary" onClick={() => alert('Add to Memory Hub clicked (not implemented)')}>
+            Add to Memory Hub
+          </Button>
+          <Button variant="secondary" onClick={() => alert('Explain in Notebook clicked (not implemented)')}>
+            Explain in Notebook
+          </Button>
+          <Button variant="secondary" onClick={() => alert('Practice this Concept clicked (not implemented)')}>
+            Practice this Concept
+          </Button>
+        </div>
+      </div>
+
+      {(prev || next) && (
+        <div className="mt-12 pt-8 border-t border-[rgba(100,255,218,0.2)] flex justify-between items-center">
+          {prev ? (
+            <Link href={prev.path} passHref>
+              <Button variant="secondary">
+                &larr; Previous: {prev.title}
+              </Button>
+            </Link>
+          ) : <div /> /* Placeholder for spacing if no prev */}
+          {next ? (
+            <Link href={next.path} passHref>
+              <Button variant="primary">
+                Next: {next.title} &rarr;
+              </Button>
+            </Link>
+          ) : <div /> /* Placeholder for spacing if no next */}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Optional: Metadata for SEO
+export async function generateMetadata({ params }: { params: { slug: string[] } }) {
+  const currentPath = `/curriculum/${params.slug.join('/')}`;
+  const node = findNodeByPath(curriculumData, currentPath);
+  if (!node) {
+    return { title: 'Page Not Found' };
+  }
+  return {
+    title: `${node.title} | SV/UVM Guide`,
+    // description: node.description || `Learn about ${node.title} in SystemVerilog and UVM.`,
+  };
+}

--- a/sv-uvm-guide/src/lib/curriculum-data.ts
+++ b/sv-uvm-guide/src/lib/curriculum-data.ts
@@ -1,0 +1,220 @@
+export interface CurriculumNode {
+  id: string; // A unique identifier, e.g., 'sv-foundations-data-types'
+  title: string;
+  path: string; // The full URL path, e.g., '/curriculum/sv-foundations/data-types/literals-and-basic-types'
+  status: 'published' | 'draft' | 'planned';
+  children?: CurriculumNode[]; // Corrected: children should be an array of CurriculumNode
+}
+
+export const curriculumData: CurriculumNode[] = [ // Changed to array to represent multiple top-level modules
+  {
+    id: 'sv-foundations',
+    title: 'SystemVerilog Foundations',
+    path: '/curriculum/sv-foundations',
+    status: 'planned',
+    children: [
+      {
+        id: 'sv-foundations-introduction',
+        title: 'Introduction to SystemVerilog Foundations',
+        path: '/curriculum/sv-foundations/introduction',
+        status: 'planned',
+      },
+      {
+        id: 'sv-foundations-data-types',
+        title: 'Data Types',
+        path: '/curriculum/sv-foundations/data-types',
+        status: 'planned',
+        children: [
+          {
+            id: 'sv-foundations-data-types-literals',
+            title: 'Literals and Basic Types',
+            path: '/curriculum/sv-foundations/data-types/literals-and-basic-types',
+            status: 'planned',
+          },
+          {
+            id: 'sv-foundations-data-types-nets-variables',
+            title: 'Nets and Variables: logic vs. wire',
+            path: '/curriculum/sv-foundations/data-types/nets-and-variables-logic-vs-wire',
+            status: 'planned',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'sv-advanced',
+    title: 'Advanced SystemVerilog Topics',
+    path: '/curriculum/sv-advanced',
+    status: 'planned',
+    children: [
+      {
+        id: 'sv-advanced-oop',
+        title: 'Object-Oriented Programming',
+        path: '/curriculum/sv-advanced/object-oriented-programming',
+        status: 'planned',
+        children: [
+          {
+            id: 'sv-advanced-oop-inheritance',
+            title: 'Inheritance, Polymorphism, and Virtual Methods',
+            path: '/curriculum/sv-advanced/object-oriented-programming/inheritance-polymorphism-virtual-methods',
+            status: 'planned',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'uvm-core',
+    title: 'UVM Core Concepts',
+    path: '/curriculum/uvm-core',
+    status: 'planned',
+    children: [
+      {
+        id: 'uvm-core-base-class-library',
+        title: 'Base Class Library',
+        path: '/curriculum/uvm-core/base-class-library',
+        status: 'planned',
+        children: [
+          {
+            id: 'uvm-core-bcl-object-vs-component',
+            title: 'uvm_object vs. uvm_component',
+            path: '/curriculum/uvm-core/base-class-library/uvm-object-vs-uvm-component',
+            status: 'planned',
+          },
+        ],
+      },
+      {
+        id: 'uvm-core-phasing',
+        title: 'Phasing and Synchronization',
+        path: '/curriculum/uvm-core/phasing-and-synchronization',
+        status: 'planned',
+        children: [
+          {
+            id: 'uvm-core-phasing-detail',
+            title: 'The UVM Phases in Detail',
+            path: '/curriculum/uvm-core/phasing-and-synchronization/the-uvm-phases-in-detail',
+            status: 'planned',
+          },
+        ],
+      },
+    ],
+  },
+];
+
+// Helper function to get a flat list of all nodes (useful for generateStaticParams)
+export function getAllCurriculumNodes(nodes: CurriculumNode[]): CurriculumNode[] {
+  let flatList: CurriculumNode[] = [];
+  for (const node of nodes) {
+    flatList.push(node);
+    if (node.children) {
+      flatList = flatList.concat(getAllCurriculumNodes(node.children));
+    }
+  }
+  return flatList;
+}
+
+// Helper function to find a node by path
+export function findNodeByPath(nodes: CurriculumNode[], path: string): CurriculumNode | undefined {
+  for (const node of nodes) {
+    if (node.path === path) {
+      return node;
+    }
+    if (node.children) {
+      const foundInChildren = findNodeByPath(node.children, path);
+      if (foundInChildren) {
+        return foundInChildren;
+      }
+    }
+  }
+  return undefined;
+}
+
+// Helper function to get breadcrumbs for a given path
+export function getBreadcrumbs(
+  nodes: CurriculumNode[],
+  currentPath: string
+): CurriculumNode[] {
+  const pathSegments = currentPath.split('/').filter(Boolean); // e.g., ['curriculum', 'sv-foundations', 'data-types']
+  const breadcrumbs: CurriculumNode[] = [];
+  let currentNodes = nodes;
+  let builtPath = '';
+
+  for (let i = 1; i < pathSegments.length; i++) { // Start from 1 to skip 'curriculum'
+    builtPath += '/' + pathSegments[i-1] ; // Path for parent
+    if (i > 1) builtPath += '/' + pathSegments[i]; else builtPath += '/' + pathSegments[i];
+
+
+    const segmentToFind = pathSegments.slice(0, i + 1).join('/');
+    const node = findNodeByPath(nodes, `/${segmentToFind}`);
+
+
+    if (node) {
+       // Check if the node is already added to avoid duplicates from nested searches
+      if (!breadcrumbs.find(b => b.id === node.id)) {
+        breadcrumbs.push(node);
+      }
+      currentNodes = node.children || [];
+    } else {
+      // If a specific segment doesn't match a node path directly,
+      // we might be looking for a parent path.
+      // This logic might need refinement based on how paths are structured.
+      const parentPath = '/' + pathSegments.slice(0, i).join('/');
+      const parentNode = findNodeByPath(nodes, parentPath);
+      if (parentNode && !breadcrumbs.find(b => b.id === parentNode.id)) {
+          // breadcrumbs.push(parentNode); // Avoid pushing parent if current segment is the actual node
+      }
+    }
+  }
+   // Add the current page itself to breadcrumbs if it's a valid node path
+  const currentNode = findNodeByPath(nodes, currentPath);
+  if (currentNode && !breadcrumbs.find(b => b.id === currentNode.id)) {
+    // Check if the last breadcrumb added is not the current node already
+    if (breadcrumbs.length === 0 || breadcrumbs[breadcrumbs.length-1].path !== currentPath) {
+       // breadcrumbs.push(currentNode); // This might be redundant if paths are exact
+    }
+  }
+
+
+  // Refined breadcrumb generation
+  const resultCrumbs: CurriculumNode[] = [];
+  let pathAcc = '';
+  for(const segment of pathSegments) {
+    pathAcc += `/${segment}`;
+    const foundNode = findNodeByPath(nodes, pathAcc);
+    if (foundNode && !resultCrumbs.find(n => n.id === foundNode.id)) {
+      resultCrumbs.push(foundNode);
+    }
+  }
+
+
+  return resultCrumbs;
+}
+
+
+// Helper function to find next and previous lessons
+export function getNextPrevLessons(
+  flatNodes: CurriculumNode[],
+  currentPath: string
+): { prev?: CurriculumNode; next?: CurriculumNode } {
+  const currentIndex = flatNodes.findIndex(node => node.path === currentPath && !node.children); // Only consider leaf nodes as "lessons"
+  if (currentIndex === -1) {
+    return {};
+  }
+
+  let prevNode: CurriculumNode | undefined = undefined;
+  for (let i = currentIndex - 1; i >= 0; i--) {
+    if (!flatNodes[i].children) { // Found previous leaf node
+      prevNode = flatNodes[i];
+      break;
+    }
+  }
+
+  let nextNode: CurriculumNode | undefined = undefined;
+  for (let i = currentIndex + 1; i < flatNodes.length; i++) {
+    if (!flatNodes[i].children) { // Found next leaf node
+      nextNode = flatNodes[i];
+      break;
+    }
+  }
+  return { prev: prevNode, next: nextNode };
+}


### PR DESCRIPTION
- Defined curriculum data structure (CurriculumNode) and populated initial sitemap data in lib/curriculum-data.ts.
- Created content generation directory structure under /content/curriculum.
- Generated MDX content for initial curriculum pages:
    - /sv-foundations/introduction
    - /sv-foundations/data-types/literals-and-basic-types
    - /sv-foundations/data-types/nets-and-variables-logic-vs-wire
    - /sv-advanced/object-oriented-programming/inheritance-polymorphism-virtual-methods
    - /uvm-core/base-class-library/uvm-object-vs-uvm-component
    - /uvm-core/phasing-and-synchronization/the-uvm-phases-in-detail
- Implemented dynamic curriculum page template (app/curriculum/[...slug]/page.tsx) using next-mdx-remote (assumed installed despite timeout) for MDX rendering.
- Created Breadcrumbs component.
- Page template includes dynamic title, breadcrumbs, MDX content rendering, end-of-lesson actions, and next/previous lesson navigation.

Note: Full automated testing (lint, type-check, test) for this phase was hindered by environment timeouts, likely related to dependency installation issues.