### PR TITLE
fix: Automatically generate Prisma client on dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "next dev",
+    "dev": "npx prisma generate && next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
This commit updates the `dev` script in `package.json` to run `npx prisma generate` before starting the Next.js development server. This ensures that the Prisma client is always up-to-date and should resolve the 'schema-engine-darwin-arm64' not found error.