### PR TITLE
Fix missing brand text color styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Contributions are what make the open source community such an amazing place to l
 
 If you have a suggestion that would make this better, please fork the repo and create a pull request. You can also simply open an issue with the tag "enhancement".
 
+### Styling
+
+The site uses Tailwind CSS with custom CSS variables. Colors like `text-brand-text-primary` are driven by variables defined in `src/app/globals.css` and mapped in `tailwind.config.ts`. Make sure these variables are present when customizing themes, otherwise the components will appear unstyled.
+
 Don't forget to give the project a star! Thanks again!
 
 1.  Fork the Project

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -18,6 +18,7 @@
     --muted-foreground: #71717a;
     --accent: #f4f4f5;
     --accent-foreground: #18181b;
+    --brand-text-primary: #18181b; /* brand primary text color for light mode */
     --destructive: #ef4444;
     --destructive-foreground: #fafafa;
     --border: #e4e4e7;
@@ -46,6 +47,7 @@
     --border: #27272a;
     --input: #27272a;
     --ring: #d4d4d8;
+    --brand-text-primary: #fafafa; /* brand primary text color for dark mode */
   }
 
   * {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -34,6 +34,7 @@ module.exports = {
           DEFAULT: "hsl(var(--accent) / <alpha-value>)",
           foreground: "hsl(var(--accent-foreground) / <alpha-value>)",
         },
+        "brand-text-primary": "hsl(var(--brand-text-primary) / <alpha-value>)",
         popover: {
           DEFAULT: "hsl(var(--popover) / <alpha-value>)",
           foreground: "hsl(var(--popover-foreground) / <alpha-value>)",
@@ -81,6 +82,7 @@ module.exports = {
           "--muted-foreground": "215.4 16.3% 46.9%",
           "--accent": "210 40% 96.1%",
           "--accent-foreground": "222.2 47.4% 11.2%",
+          "--brand-text-primary": "222.2 47.4% 11.2%",
           "--destructive": "0 84.2% 60.2%",
           "--destructive-foreground": "210 40% 98%",
           "--border": "214.3 31.8% 91.4%",
@@ -103,6 +105,7 @@ module.exports = {
           "--muted-foreground": "215 20.2% 65.1%",
           "--accent": "217.2 32.6% 17.5%",
           "--accent-foreground": "210 40% 98%",
+          "--brand-text-primary": "210 40% 98%",
           "--destructive": "0 62.8% 30.6%",
           "--destructive-foreground": "210 40% 98%",
           "--border": "217.2 32.6% 17.5%",


### PR DESCRIPTION
## Summary
- define `--brand-text-primary` variable in `globals.css`
- expose `brand-text-primary` color in Tailwind theme
- set default values for the color in the Tailwind base plugin
- document how styling variables work in README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a2cbfffd883308b7871d671df5f6b