### PR TITLE
Fix text color class names

### DIFF
--- a/src/app/curriculum/page.tsx
+++ b/src/app/curriculum/page.tsx
@@ -9,7 +9,7 @@ export default function CurriculumPage() {
       <h1 className="text-3xl sm:text-4xl font-bold text-accent font-sans mb-6 pb-2 border-b border-secondary">
         Learning Journey
       </h1>
-      <p className="text-lg text-text-secondary font-body leading-relaxed mb-8">
+      <p className="text-lg text-muted-foreground font-body leading-relaxed mb-8">
         Navigate through the modules to master SystemVerilog and UVM.
       </p>
       <Accordion className="w-full">
@@ -23,11 +23,11 @@ export default function CurriculumPage() {
                       <li key={topic.slug}>
                         <Link
                           href={`/curriculum/${module.slug}/${section.slug}/${topic.slug}`}
-                          className="text-text-primary hover:text-accent transition-colors"
+                          className="text-brand-text-primary hover:text-accent transition-colors"
                         >
                           {topic.title}
                         </Link>
-                        <p className="text-text-secondary text-sm">{topic.description}</p>
+                        <p className="text-muted-foreground text-sm">{topic.description}</p>
                       </li>
                     ))}
                   </ul>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -52,7 +52,7 @@ const Navbar = () => {
             <button
               onClick={toggleNavbar}
               type="button"
-              className="inline-flex items-center justify-center p-2 rounded-md text-text-primary hover:text-accent focus:outline-none"
+              className="inline-flex items-center justify-center p-2 rounded-md text-brand-text-primary hover:text-accent focus:outline-none"
               aria-controls="mobile-menu"
               aria-expanded={isOpen}
             >
@@ -79,7 +79,7 @@ const Navbar = () => {
                   key={link.href}
                   href={link.href}
                   onClick={() => setIsOpen(false)}
-                  className="text-text-primary hover:text-accent block px-3 py-2 rounded-md text-base font-medium transition-colors"
+                  className="text-brand-text-primary hover:text-accent block px-3 py-2 rounded-md text-base font-medium transition-colors"
                 >
                   {link.label}
                 </Link>

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -38,14 +38,14 @@ const CardHeader: React.FC<CardProps> = ({ children, className, ...props }) => (
 CardHeader.displayName = "CardHeader";
 
 const CardTitle: React.FC<React.HTMLAttributes<HTMLHeadingElement>> = ({ children, className, ...props }) => (
-  <h3 className={twMerge(clsx("text-2xl font-semibold leading-none tracking-tight text-primary-text", className))} {...props}>
+  <h3 className={twMerge(clsx("text-2xl font-semibold leading-none tracking-tight text-brand-text-primary", className))} {...props}>
     {children}
   </h3>
 );
 CardTitle.displayName = "CardTitle";
 
 const CardDescription: React.FC<React.HTMLAttributes<HTMLParagraphElement>> = ({ children, className, ...props }) => (
-  <p className={twMerge(clsx("text-sm text-primary-text/80", className))} {...props}>
+  <p className={twMerge(clsx("text-sm text-brand-text-primary/80", className))} {...props}>
     {children}
   </p>
 );


### PR DESCRIPTION
## Summary
- replace outdated Tailwind color classes

## Testing
- `npm test`
- `npm run lint` *(fails: no-sync-scripts, no-assign-module-variable)*

------
https://chatgpt.com/codex/tasks/task_e_687ab71884e88330937883337653563c