### PR TITLE
Add danger color alias for Tailwind

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -26,6 +26,10 @@ const config: Config = {
           DEFAULT: "hsl(var(--destructive) / <alpha-value>)",
           foreground: "hsl(var(--destructive-foreground) / <alpha-value>)",
         },
+        danger: {
+          DEFAULT: "hsl(var(--destructive) / <alpha-value>)",
+          foreground: "hsl(var(--destructive-foreground) / <alpha-value>)",
+        },
         success: {
           DEFAULT: "hsl(var(--success) / <alpha-value>)",
           foreground: "hsl(var(--success-foreground) / <alpha-value>)",


### PR DESCRIPTION
## Summary
- add a `danger` color to `tailwind.config.ts` that aliases the existing `destructive` color

## Testing
- `npm test` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687ab71ba1388330ba78ba0823c2a796