### PR TITLE
Add env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+GEMINI_API_KEY=
+SESSION_SECRET=
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres?schema=public"

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -26,10 +26,12 @@ Before you can run the application, you need to create a `.env` file and set the
     ```sh
     cp .env.example .env
     ```
-2.  Open the `.env` file and add your Gemini API key and a session secret.
+2.  Open the `.env` file and add your Gemini API key, session secret, and Google OAuth credentials.
     ```
     GEMINI_API_KEY="YOUR_API_KEY"
     SESSION_SECRET="YOUR_SESSION_SECRET"
+    GOOGLE_CLIENT_ID="YOUR_GOOGLE_CLIENT_ID"
+    GOOGLE_CLIENT_SECRET="YOUR_GOOGLE_CLIENT_SECRET"
     ```
 3.  The `DATABASE_URL` is already set in the `.env.example` file, but you can change it if you need to.
 


### PR DESCRIPTION
## Summary
- provide a `.env.example` template
- allow tracking `.env.example`
- reference Google OAuth variables in README

## Testing
- `npm test` *(fails: Failed to fetch sha256 checksum at https://binaries.prisma.sh/... - 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687bca734590833092ca36720a180201