### PR TITLE
Fix PostCSS configuration

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,8 +1,6 @@
-import tailwind from '@tailwindcss/postcss';
+import tailwindcss from 'tailwindcss';
+import autoprefixer from 'autoprefixer';
 
 export default {
-  plugins: {
-    tailwind,
-    autoprefixer: {}
-  }
+  plugins: [tailwindcss, autoprefixer]
 };


### PR DESCRIPTION
## Summary
- import autoprefixer plugin
- configure plugins array in PostCSS

## Testing
- `npm install`
- `npx next dev` *(fails to run `npm run dev` due to blocked Prisma download)*

------
https://chatgpt.com/codex/tasks/task_e_687c4f8b94048330b56d33b0edfaef93