### PR TITLE
Add multiple themes

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,6 +4,8 @@
 
 @layer base {
   :root {
+    --radius: 0.5rem;
+    /* default light theme */
     --background: 36 83% 97%; /* hsl(36, 83%, 97%) from #FDF8F0 */
     --foreground: 0 0% 29%; /* hsl(0, 0%, 29%) from #4A4A4A */
     --primary: 344 100% 63%; /* hsl(344, 100%, 63%) from #FF4081 */
@@ -21,14 +23,194 @@
     --border: 214.3 31.8% 91.4%;
     --input: 214.3 31.8% 91.4%;
     --ring: 222.2 84% 4.9%;
-    --radius: 0.5rem;
   }
 
-  .dark {
+  html.default-light {
+    --background: 36 83% 97%;
+    --foreground: 0 0% 29%;
+    --primary: 344 100% 63%;
+    --accent: 14 100% 70%;
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 222.2 84% 4.9%;
+  }
+
+  html.default-dark,
+  html.dark {
     --background: 212 78% 11%; /* hsl(212, 78%, 11%) from #0A192F */
     --foreground: 165 100% 70%; /* hsl(165, 100%, 70%) from #64FFDA */
     --primary: 199 100% 50%; /* hsl(199, 100%, 50%) from #00BFFF */
     --accent: 165 100% 70%; /* hsl(165, 100%, 70%) from #64FFDA */
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+    --accent-foreground: 210 40% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 212.7 26.8% 83.9%;
+  }
+
+  html.ocean-light {
+    --background: 204 100% 97%;
+    --foreground: 214 52% 25%;
+    --primary: 199 89% 48%;
+    --accent: 175 84% 32%;
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 222.2 84% 4.9%;
+  }
+
+  html.ocean-dark {
+    --background: 222 47% 11%;
+    --foreground: 204 94% 94%;
+    --primary: 198 93% 60%;
+    --accent: 172 66% 50%;
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+    --accent-foreground: 210 40% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 212.7 26.8% 83.9%;
+  }
+
+  html.sunset-light {
+    --background: 33 100% 96%;
+    --foreground: 240 5% 26%;
+    --primary: 27 96% 61%;
+    --accent: 329 86% 70%;
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 222.2 84% 4.9%;
+  }
+
+  html.sunset-dark {
+    --background: 215 28% 17%;
+    --foreground: 55 97% 88%;
+    --primary: 0 94% 82%;
+    --accent: 327 87% 82%;
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+    --accent-foreground: 210 40% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 212.7 26.8% 83.9%;
+  }
+
+  html.forest-light {
+    --background: 138 76% 97%;
+    --foreground: 163 88% 20%;
+    --primary: 158 64% 52%;
+    --accent: 160 84% 39%;
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 222.2 84% 4.9%;
+  }
+
+  html.forest-dark {
+    --background: 166 91% 9%;
+    --foreground: 149 80% 90%;
+    --primary: 161 94% 30%;
+    --accent: 189 94% 43%;
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+    --accent-foreground: 210 40% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 212.7 26.8% 83.9%;
+  }
+
+  html.violet-light {
+    --background: 250 100% 98%;
+    --foreground: 264 67% 35%;
+    --primary: 262 83% 58%;
+    --accent: 293 69% 49%;
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 222.2 84% 4.9%;
+  }
+
+  html.violet-dark {
+    --background: 244 47% 20%;
+    --foreground: 226 100% 94%;
+    --primary: 255 92% 76%;
+    --accent: 292 91% 73%;
     --card: 222.2 84% 4.9%;
     --card-foreground: 210 40% 98%;
     --primary-foreground: 222.2 47.4% 11.2%;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -72,7 +72,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
       <body className={`${inter.variable} ${jetbrains_mono.variable} ${calSans.variable} font-sans`}>
         <ThemeProvider
           attribute="class"
-          defaultTheme="dark"
+          defaultTheme="default-dark"
           disableTransitionOnChange
         >
           <SessionProvider>

--- a/src/components/providers/ThemeProvider.tsx
+++ b/src/components/providers/ThemeProvider.tsx
@@ -4,6 +4,38 @@ import * as React from "react";
 import { ThemeProvider as NextThemesProvider } from "next-themes";
 import { type ThemeProviderProps } from "next-themes/dist/types";
 
+const themeNames = [
+  "default-light",
+  "default-dark",
+  "ocean-light",
+  "ocean-dark",
+  "sunset-light",
+  "sunset-dark",
+  "forest-light",
+  "forest-dark",
+  "violet-light",
+  "violet-dark",
+] as const;
+
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
-  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+  return (
+    <NextThemesProvider
+      themes={themeNames as unknown as string[]}
+      value={{
+        "default-light": "default-light",
+        "default-dark": "default-dark dark",
+        "ocean-light": "ocean-light",
+        "ocean-dark": "ocean-dark dark",
+        "sunset-light": "sunset-light",
+        "sunset-dark": "sunset-dark dark",
+        "forest-light": "forest-light",
+        "forest-dark": "forest-dark dark",
+        "violet-light": "violet-light",
+        "violet-dark": "violet-dark dark",
+      }}
+      {...props}
+    >
+      {children}
+    </NextThemesProvider>
+  );
 }

--- a/src/components/ui/ThemeSwitcher.tsx
+++ b/src/components/ui/ThemeSwitcher.tsx
@@ -1,23 +1,65 @@
 "use client";
 
 import * as React from "react";
+import { useEffect, useState } from "react";
 import { Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 
 import { Button } from "@/components/ui/Button";
 
+const themeOptions = [
+  { key: "default", label: "Default" },
+  { key: "ocean", label: "Ocean" },
+  { key: "sunset", label: "Sunset" },
+  { key: "forest", label: "Forest" },
+  { key: "violet", label: "Violet" },
+];
+
 export function ThemeSwitcher() {
   const { theme, setTheme } = useTheme();
+  const [currentTheme, setCurrentTheme] = useState("default");
+  const [mode, setMode] = useState<"light" | "dark">("dark");
+
+  useEffect(() => {
+    if (!theme) return;
+    const parts = theme.split("-");
+    const m = parts.pop();
+    if (m === "light" || m === "dark") {
+      setMode(m);
+      setCurrentTheme(parts.join("-"));
+    }
+  }, [theme]);
+
+  const handleSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newTheme = e.target.value;
+    setCurrentTheme(newTheme);
+    setTheme(`${newTheme}-${mode}`);
+  };
+
+  const toggleMode = () => {
+    const newMode = mode === "light" ? "dark" : "light";
+    setMode(newMode);
+    setTheme(`${currentTheme}-${newMode}`);
+  };
 
   return (
-    <Button
-      variant="ghost"
-      size="icon"
-      onClick={() => setTheme(theme === "light" ? "dark" : "light")}
-    >
-      <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-      <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-      <span className="sr-only">Toggle theme</span>
-    </Button>
+    <div className="flex items-center space-x-2">
+      <select
+        value={currentTheme}
+        onChange={handleSelect}
+        className="rounded-md border border-input bg-background p-2 text-sm"
+      >
+        {themeOptions.map((t) => (
+          <option key={t.key} value={t.key}>
+            {t.label}
+          </option>
+        ))}
+      </select>
+      <Button variant="ghost" size="icon" onClick={toggleMode}>
+        <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+        <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+        <span className="sr-only">Toggle theme</span>
+      </Button>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- introduce 4 new color theme pairs and update globals
- extend ThemeProvider to register new theme names and map dark versions
- update layout to use new `default-dark` theme
- enhance ThemeSwitcher with dropdown for theme selection and dark/light toggle

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: `tsc` not found)*
- `npm test` *(fails: `playwright` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688190816cf483309f6772493fb67fbc