### PR TITLE
Add UVM core and testbench modules

### DIFF
--- a/content/curriculum/uvm-building/essentials/agents-and-environment.mdx
+++ b/content/curriculum/uvm-building/essentials/agents-and-environment.mdx
@@ -1,0 +1,33 @@
+---
+title: "Agents and Environment"
+---
+
+import CodeBlock from '/src/components/ui/CodeBlock'
+
+## Level 1: Definitions and Analogies
+
+An Agent is a **team**: driver, sequencer, and monitor. An Environment is the **department** that groups one or more agents with scoreboards and other components.
+
+## Level 2: Connecting Components
+
+```systemverilog
+class my_agent extends uvm_agent;
+  `uvm_component_utils(my_agent)
+  my_driver d;
+  my_sequencer s;
+  my_monitor m;
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    if (is_active) begin
+      d = my_driver::type_id::create("d", this);
+      s = my_sequencer::type_id::create("s", this);
+    end
+    m = my_monitor::type_id::create("m", this);
+  endfunction
+endclass
+```
+
+## Level 3: Advanced Practices
+
+* Use a **virtual sequencer** in the environment to coordinate multiple agents.
+* Passive agents are ideal for system-level observation without stimulus.

--- a/content/curriculum/uvm-building/essentials/analysis-components.mdx
+++ b/content/curriculum/uvm-building/essentials/analysis-components.mdx
@@ -1,0 +1,43 @@
+---
+title: "Analysis Components"
+---
+
+import CodeBlock from '/src/components/ui/CodeBlock'
+import Quiz from '/src/components/ui/Quiz'
+
+## Level 1: Definitions and Analogies
+
+Monitors act like **security cameras**, observing traffic and reporting to subscribers. Scoreboards are the **referees** checking that what happened matches expectations.
+
+## Level 2: Monitor and Scoreboard Example
+
+```systemverilog
+class my_monitor extends uvm_monitor;
+  `uvm_component_utils(my_monitor)
+  uvm_analysis_port#(my_item) ap;
+  function new(string name, uvm_component parent);
+    super.new(name,parent);
+    ap = new("ap", this);
+  endfunction
+  task run_phase(uvm_phase phase);
+    my_item tr = my_item::type_id::create("tr");
+    ap.write(tr);
+  endtask
+endclass
+
+class my_scoreboard extends uvm_scoreboard;
+  `uvm_component_utils(my_scoreboard)
+  uvm_analysis_export#(my_item) exp;
+  function new(string name, uvm_component parent);
+    super.new(name,parent);
+    exp = new("exp", this);
+  endfunction
+endclass
+```
+
+## Level 3: Pitfalls
+
+* Monitors must **never drive** signals.
+* Subscribers can be chained via analysis ports, but avoid long chains that hide bugs.
+
+<Quiz questions={[{question:'Which component receives analysis exports?', options:['Driver','Monitor','Scoreboard','Sequencer'], correctAnswer:'Scoreboard'}]} />

--- a/content/curriculum/uvm-building/essentials/architecture-overview.mdx
+++ b/content/curriculum/uvm-building/essentials/architecture-overview.mdx
@@ -1,0 +1,18 @@
+---
+title: "Testbench Architecture Overview"
+---
+
+import AnimatedUvmTestbenchDiagram from '/src/components/diagrams/AnimatedUvmTestbenchDiagram'
+
+## Level 1: Definitions and Analogies
+
+A UVM testbench resembles a **department** in a company. Each Agent is a small team (driver, sequencer, monitor) and the Environment is the department that brings teams together under a single manager – the `uvm_test`.
+
+## Level 2: Diagram
+
+<AnimatedUvmTestbenchDiagram />
+
+## Level 3: Best Practices
+
+* Keep agents self‑contained for reuse.
+* Top environments often compose multiple agents and scoreboards.

--- a/content/curriculum/uvm-building/essentials/stimulus-generation.mdx
+++ b/content/curriculum/uvm-building/essentials/stimulus-generation.mdx
@@ -1,0 +1,32 @@
+---
+title: "Stimulus Generation"
+---
+
+import AnimatedUvmSequenceDriverHandshakeDiagram from '/src/components/diagrams/AnimatedUvmSequenceDriverHandshakeDiagram'
+import CodeBlock from '/src/components/ui/CodeBlock'
+import Quiz from '/src/components/ui/Quiz'
+
+## Level 1: Definition and Analogy
+
+Sequences drive the intent of a test like a **playlist** for a DJ. The sequencer hands items to the driver, which plays them on the DUT pins.
+
+## Level 2: Handshake Example
+
+<AnimatedUvmSequenceDriverHandshakeDiagram />
+
+```systemverilog
+seq_item_port.get_next_item(req);
+// drive req
+seq_item_port.item_done();
+```
+
+## Level 3: Advanced Tips
+
+* Use `grab()` and `lock()` to control sequencer arbitration when multiple sequences run.
+* Sequence libraries package related sequences for reuse.
+
+<Quiz questions={[{
+  question: 'Which component drives stimulus?',
+  options: ['Monitor','Driver','Scoreboard','Environment'],
+  correctAnswer: 'Driver'
+}]} />

--- a/content/curriculum/uvm-core/fundamentals/base-classes.mdx
+++ b/content/curriculum/uvm-core/fundamentals/base-classes.mdx
@@ -1,0 +1,36 @@
+---
+title: "UVM Base Classes"
+---
+
+import CodeBlock from '/src/components/ui/CodeBlock'
+import UvmHierarchySunburstChart from '/src/components/charts/UvmHierarchySunburstChart'
+
+## Level 1: Definition and Analogy
+
+`uvm_object` and `uvm_component` form the root of every UVM class. Think of `uvm_object` as a **package** that is shipped around, while `uvm_component` is a **building** permanently placed in the testbench city. The base classes exist so that every piece of data or infrastructure in UVM follows common creation and reporting rules.
+
+## Level 2: In‑Depth Walkthrough
+
+The `uvm_component_utils` macro registers a component with the factory so it can be created later. The `build_phase` is where components are typically instantiated.
+
+```systemverilog
+class my_driver extends uvm_driver#(my_item);
+  `uvm_component_utils(my_driver)
+  function new(string name, uvm_component parent);
+    super.new(name,parent);
+  endfunction
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    // create a transaction via the factory
+    my_item tr = my_item::type_id::create("tr");
+  endfunction
+endclass
+```
+
+<UvmHierarchySunburstChart />
+
+## Level 3: Edge‑Case Insights
+
+* `uvm_component` participates in phasing; forgetting `super.build_phase` can break hierarchies.
+* `uvm_object` derived classes should use the `clone` method when copying to preserve factory type.
+* Remember: **"Components are buildings, objects are packages"** – a quick mnemonic seasoned engineers repeat.

--- a/content/curriculum/uvm-core/fundamentals/component-communication.mdx
+++ b/content/curriculum/uvm-core/fundamentals/component-communication.mdx
@@ -1,0 +1,52 @@
+---
+title: "Component Communication"
+---
+
+import CodeBlock from '/src/components/ui/CodeBlock'
+
+## Level 1: Definition and Analogy
+
+TLM ports in UVM act like **phone lines** between components. A driver "calls" the sequencer through a `seq_item_port`, while monitors broadcast transactions using `uvm_analysis_port` – much like a radio station reaching many listeners.
+
+## Level 2: In‑Depth Walkthrough
+
+### uvm_config_db Example
+
+```systemverilog
+// Set
+uvm_config_db#(int)::set(null, "*", "mtu", 1500);
+// Get
+int mtu;
+if(!uvm_config_db#(int)::get(this, "", "mtu", mtu))
+  `uvm_fatal("CFG", "MTU not set")
+```
+
+### Analysis Port to Subscriber
+
+```systemverilog
+class my_monitor extends uvm_monitor;
+  `uvm_component_utils(my_monitor)
+  uvm_analysis_port#(my_item) ap;
+  function new(string name, uvm_component parent);
+    super.new(name,parent);
+    ap = new("ap", this);
+  endfunction
+  task run_phase(uvm_phase phase);
+    my_item tr = my_item::type_id::create("tr");
+    ap.write(tr);
+  endtask
+endclass
+
+class my_scoreboard extends uvm_subscriber#(my_item);
+  `uvm_component_utils(my_scoreboard)
+  function void write(my_item t);
+    // check t
+  endfunction
+endclass
+```
+
+## Level 3: Edge‑Case Insights
+
+* `uvm_resource_db` can override `uvm_config_db` values; remember precedence when debugging.
+* TLM 2.0 provides timed transactions but is rarely used in simple testbenches.
+* Mnemonic: **"Ports phone home"** – recall that ports initiate communication, exports answer.

--- a/content/curriculum/uvm-core/fundamentals/factory.mdx
+++ b/content/curriculum/uvm-core/fundamentals/factory.mdx
@@ -1,0 +1,40 @@
+---
+title: "UVM Factory"
+---
+
+import CodeBlock from '/src/components/ui/CodeBlock'
+import Link from 'next/link'
+
+## Level 1: Definition and Analogy
+
+The UVM Factory is like a **customizable production line**. You order the type you want and the factory delivers it, letting you swap models without rewiring the assembly line. It solves the problem of replacing components or sequence items for specific tests without editing their creators.
+
+## Level 2: In‑Depth Walkthrough
+
+### Registration and Creation
+
+```systemverilog
+class my_item extends uvm_sequence_item;
+  `uvm_object_utils(my_item)
+endclass
+
+class my_driver extends uvm_driver#(my_item);
+  `uvm_component_utils(my_driver)
+endclass
+
+my_item item = my_item::type_id::create("item");
+```
+
+### Overrides
+
+```systemverilog
+factory.set_type_override_by_type(my_item::get_type(), my_item_ext::get_type());
+```
+
+## Level 3: Edge‑Case Insights
+
+* **Type vs Instance Overrides:** Type overrides replace all creations; instance overrides target one path.
+* Use `+uvm_set_inst_override` and `+uvm_set_type_override` from the command line for debugging.
+* Veteran tip: **"Factory = UVM's switchboard operator"** – it redirects calls to create objects.
+
+[Next: Phasing](./phasing)

--- a/content/curriculum/uvm-core/fundamentals/phasing.mdx
+++ b/content/curriculum/uvm-core/fundamentals/phasing.mdx
@@ -1,0 +1,35 @@
+---
+title: "Phasing"
+---
+
+import CodeBlock from '/src/components/ui/CodeBlock'
+import UvmPhasingDiagram from '/src/components/diagrams/UvmPhasingDiagram'
+
+## Level 1: Definition and Analogy
+
+UVM phasing is the **schedule** that orchestrates every component. Like stages of a concert rehearsal, components prepare (`build_phase`), connect instruments (`connect_phase`), perform (`run_phase`), and wrap up (`report_phase`).
+
+## Level 2: In‑Depth Walkthrough
+
+```systemverilog
+class my_env extends uvm_env;
+  `uvm_component_utils(my_env)
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    // create sub components
+  endfunction
+  task run_phase(uvm_phase phase);
+    phase.raise_objection(this);
+    // stimulus
+    phase.drop_objection(this);
+  endtask
+endclass
+```
+
+<UvmPhasingDiagram />
+
+## Level 3: Edge‑Case Insights
+
+* Always call `super.build_phase` and friends to ensure parents create children.
+* Phases can be jumped with `phase.jump(uvm_reset_phase::get())`, but use sparingly.
+* Remember: **"Phasing is the rehearsal schedule"** – keep components in sync.

--- a/src/components/diagrams/UvmPhasingDiagram.tsx
+++ b/src/components/diagrams/UvmPhasingDiagram.tsx
@@ -1,0 +1,32 @@
+"use client";
+import React from 'react';
+import { motion } from 'framer-motion';
+
+const phases = [
+  'build_phase',
+  'connect_phase',
+  'end_of_elaboration_phase',
+  'start_of_simulation_phase',
+  'run_phase',
+  'extract_phase',
+  'check_phase',
+  'report_phase'
+];
+
+const UvmPhasingDiagram: React.FC = () => (
+  <div className="flex flex-col space-y-2">
+    {phases.map((p, i) => (
+      <motion.div
+        key={p}
+        className="px-4 py-2 rounded border border-primary/40 bg-primary/10"
+        initial={{ opacity: 0, x: -20 }}
+        animate={{ opacity: 1, x: 0 }}
+        transition={{ delay: i * 0.1 }}
+      >
+        {p}
+      </motion.div>
+    ))}
+  </div>
+);
+
+export default UvmPhasingDiagram;

--- a/src/lib/curriculum-data.ts
+++ b/src/lib/curriculum-data.ts
@@ -107,7 +107,40 @@ export const curriculumData: Module[] = [
                 { title: "Basic UVM Sequences", slug: "index", description: "How UVM components talk to each other." },
             ]
         },
-    ]
+  },
+  {
+      title: "The UVM Universe - Core Concepts",
+      slug: "uvm-core",
+      tier: "T2",
+      sections: [
+        {
+          title: "Fundamentals",
+          slug: "fundamentals",
+          topics: [
+            { title: "UVM Base Classes", slug: "base-classes", description: "uvm_object vs uvm_component." },
+            { title: "Component Communication", slug: "component-communication", description: "TLM ports and analysis ports." },
+            { title: "Factory", slug: "factory", description: "Factory overrides and creation." },
+            { title: "Phasing", slug: "phasing", description: "UVM phasing mechanism." }
+          ]
+        }
+      ]
+  },
+  {
+      title: "Building a UVM Testbench",
+      slug: "uvm-building",
+      tier: "T2",
+      sections: [
+        {
+          title: "Essentials",
+          slug: "essentials",
+          topics: [
+            { title: "Architecture Overview", slug: "architecture-overview", description: "Overview of a UVM testbench." },
+            { title: "Stimulus Generation", slug: "stimulus-generation", description: "Sequences and driver handshake." },
+            { title: "Analysis Components", slug: "analysis-components", description: "Monitors, subscribers, scoreboards." },
+            { title: "Agents and Environment", slug: "agents-and-environment", description: "Agent vs environment." }
+          ]
+        }
+      ]
   },
   {
       title: "Advanced",

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+test('factory link navigates to phasing page', async ({ page }) => {
+  await page.goto('/curriculum/uvm-core/fundamentals/factory');
+  await page.click('a:has-text("Phasing")');
+  await expect(page).toHaveURL('/curriculum/uvm-core/fundamentals/phasing');
+  await expect(page.locator('h1')).toContainText('Phasing');
+});


### PR DESCRIPTION
## Summary
- expand curriculum data to include new `uvm-core` and `uvm-building` sections
- add MDX content for UVM core concepts and testbench building
- create `UvmPhasingDiagram` component for phase visuals
- add navigation test verifying Factory → Phasing link

## Testing
- `npm install`
- `npm test` *(fails: Failed to fetch the engine file at https://binaries.prisma.sh/... 403 Forbidden)*
- `npm run dev` *(fails: Failed to fetch the engine file at https://binaries.prisma.sh/... 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6881babc73a483308f61d87c2456f734