### PR TITLE
Add advanced UVM and verification craft content

### DIFF
--- a/content/curriculum/T3_Advanced/A-UVM-5_Advanced_UVM_Techniques/index.mdx
+++ b/content/curriculum/T3_Advanced/A-UVM-5_Advanced_UVM_Techniques/index.mdx
@@ -1,17 +1,110 @@
 import { InfoPage } from "@/components/templates/InfoPage";
+import InteractiveCode from "@/components/ui/InteractiveCode";
 
 export const metadata = {
-  title: "Advanced UVM | Advanced UVM Techniques & Strategy",
-  description: "...",
+  title: "Advanced UVM Techniques & Strategy | Advanced UVM",
+  description: "Expert-level concepts like RAL, virtual sequences, callbacks, and coverage integration.",
 };
 
-<InfoPage
-  title="Advanced UVM"
-  uvm_concept_tags={["advanced uvm"]}
->
+<InfoPage title="Advanced UVM Techniques & Strategy" uvm_concept_tags={["ral","virtual sequence","callback","coverage"]}>
 
-  ## Advanced UVM
+## Level 1: Quick Overviews
 
-  This section is under construction. Please check back later.
+- **Register Abstraction Layer (RAL)** – A framework to model DUT registers as objects. It lets tests read/write registers consistently and keeps a mirrored view of the hardware.
+- **Virtual Sequences & Advanced Sequencing** – Virtual sequences orchestrate multiple sequencers for complex scenarios such as resets or simultaneous bus traffic.
+- **UVM Extensibility** – Callbacks and custom phases allow code to hook into the standard UVM flow without modifying existing components.
+- **Functional Coverage in UVM** – Covergroups embedded in monitors or scoreboards collect metrics that link back to the verification plan.
+
+## Level 2: Detailed Examples
+
+### RAL Basics
+<InteractiveCode
+  code={`class my_reg extends uvm_reg;
+  rand uvm_reg_field f;
+  function new(); super.new("my_reg", 8, UVM_NO_COVERAGE); endfunction
+  virtual function void build();
+    f = uvm_reg_field::type_id::create("f");
+    f.configure(this, 8, 0, "RW", 0, 0, 1, 0);
+  endfunction
+endclass
+
+class my_block extends uvm_reg_block;
+  my_reg r;
+  virtual function void build();
+    r = my_reg::type_id::create("r");
+    r.configure(this, null);
+    r.build();
+    default_map = create_map("sbus", 'h0, 4, UVM_LITTLE_ENDIAN);
+    default_map.add_reg(r, 'h0, "RW");
+  endfunction
+endclass
+
+class reg_seq extends uvm_sequence#(uvm_reg_item);
+  my_block model;
+  virtual task body();
+    uvm_status_e status;
+    model.r.write(status, 'hAA, UVM_FRONTDOOR);
+    model.r.write(status, 'h55, UVM_BACKDOOR);
+  endtask
+endclass`}
+  language="systemverilog"
+  explanationSteps={[
+    { target: "1-7", title: "Register Definition", explanation: "Define fields inside a uvm_reg class." },
+    { target: "9-18", title: "Register Block", explanation: "Registers are placed into maps for addressability." },
+    { target: "20-30", title: "Frontdoor vs Backdoor", explanation: "Sequences can access regs via bus or directly." }
+  ]}
+/>
+
+### Advanced Sequencing
+<InteractiveCode
+  code={`class top_virtual_seq extends uvm_sequence;
+  virtual task body();
+    p_sequencer.seqrA.grab(this);
+    fork
+      seqA.start(p_sequencer.seqrA);
+      seqB.start(p_sequencer.seqrB);
+    join
+    p_sequencer.seqrA.ungrab(this);
+  endtask
+endclass`}
+  language="systemverilog"
+  explanationSteps={[
+    { target: "2-3", explanation: "Grab locks a sequencer for exclusive use." },
+    { target: "4-6", explanation: "Start child sequences on two sequencers." },
+    { target: "7", explanation: "Release the lock when done." }
+  ]}
+/>
+
+### Custom Phase
+<InteractiveCode
+  code={`class reset_phase extends uvm_phase;
+  function new(); super.new("reset_phase", UVM_PHASE_SCHEDULE | UVM_PHASE_NODE); endfunction
+  virtual task exec_task(uvm_component c, uvm_phase p);
+    ` + "`uvm_info(\"RESET\", \"Applying reset\", UVM_LOW)" + `
+  endtask
+endclass`}
+  language="systemverilog"
+  explanationSteps={[{target:"1-5", explanation:"Define a new phase and print reset"}]}
+/>
+
+### Coverage Monitor
+<InteractiveCode
+  code={`class monitor;
+  covergroup cg;
+    cp_type: coverpoint tr.type;
+  endgroup
+  function new(); cg = new(); endfunction
+  function void write(tr); cg.sample(); endfunction
+endclass`}
+  language="systemverilog"
+  explanationSteps={[{target:"2-5", explanation:"Covergroup defined in monitor and sampled on write."}]}
+/>
+
+## Level 3: Expert Insights
+
+- **RAL Naming** – Use consistent prefix/suffix conventions so the predictor can associate bus transactions with model fields.
+- **Sequencer Handles** – Always access sequencers via `p_sequencer` to avoid type mismatches. Be cautious with `grab`/`lock`; forgetting to release can stall simulation.
+- **Callbacks vs Factory vs ConfigDB** – Use callbacks for localized behavior hooks, factory overrides for substituting component types, and config DB for parameter-like settings.
+- **Phase Order Mnemonic** – Remember "build, connect, end_of_elaboration, start" to keep custom phases aligned.
 
 </InfoPage>

--- a/content/curriculum/T4_Expert/E-CUST-1_UVM_Methodology_Customization/index.mdx
+++ b/content/curriculum/T4_Expert/E-CUST-1_UVM_Methodology_Customization/index.mdx
@@ -1,17 +1,34 @@
 import { InfoPage } from "@/components/templates/InfoPage";
+import Alert from "@/components/ui/Alert";
+import Quiz from "@/components/ui/Quiz";
 
 export const metadata = {
   title: "Professional Verification Craft | The Professional Verification Craft",
-  description: "...",
+  description: "Planning and process best practices for verification engineers.",
 };
 
-<InfoPage
-  title="Professional Verification Craft"
-  uvm_concept_tags={["verification craft"]}
->
+<InfoPage title="The Professional Verification Craft" uvm_concept_tags={["vplan","regression","vip","dpi"]}>
 
-  ## Professional Verification Craft
+## Level 1: What Is a V-Plan?
 
-  This section is under construction. Please check back later.
+A **Verification Plan (V-Plan)** is the blueprint linking requirements to tests and coverage. It answers *"what must we verify?"* and provides measurable goals.
+
+> Like architectural drawings for a house, the V-Plan ensures every feature is accounted for before building begins.
+
+## Level 2: Planning & Coverage Strategy
+
+<Alert>Maintain a single source of truth. Features, tests, and coverage points should trace back to the V-Plan.</Alert>
+
+A typical document lists DUT features, associated test scenarios, and the functional coverage items that prove those scenarios occurred. Coverage reports feed back into the plan to track closure progress.
+
+<Quiz questions={[{
+  question: "Which metric indicates coverage closure?",
+  options: ["Functional coverage", "Lines of code", "Simulation time", "Bug count"],
+  correctAnswer: "Functional coverage"
+}]}/>
+
+## Level 3: Veteran Commentary
+
+Seasoned engineers treat the V-Plan as a living contract. During regression triage, failing tests are mapped back to plan items so gaps become immediately visible. It's less about hitting 100% and more about demonstrating intent coverage.
 
 </InfoPage>

--- a/content/curriculum/T4_Expert/E-DBG-1_Advanced_UVM_Debug_Methodologies/effective-debug.mdx
+++ b/content/curriculum/T4_Expert/E-DBG-1_Advanced_UVM_Debug_Methodologies/effective-debug.mdx
@@ -2,16 +2,22 @@ import { InfoPage } from "@/components/templates/InfoPage";
 
 export const metadata = {
   title: "Effective Debug Techniques in UVM | The Professional Verification Craft",
-  description: "...",
+  description: "Tried-and-true methods for diagnosing tricky failures.",
 };
 
-<InfoPage
-  title="Effective Debug Techniques in UVM"
-  uvm_concept_tags={["debug", "UVM"]}
->
+<InfoPage title="Effective Debug Techniques in UVM" uvm_concept_tags={["debug"]}>
 
-  ## Effective Debug Techniques in UVM
+## Level 1
 
-  This section is under construction. Please check back later.
+Debugging is detective work. Start by narrowing down what changed between a passing and failing run.
+
+## Level 2
+
+- Use `uvm_info` with verbosity levels to toggle detail.
+- Add waveform triggers around key events.
+
+## Level 3
+
+Long simulations often mask the real failure. Divide and conquer by reducing randomization or time until the bug reproduces in seconds.
 
 </InfoPage>

--- a/content/curriculum/T4_Expert/E-DBG-1_Advanced_UVM_Debug_Methodologies/reusable-vip.mdx
+++ b/content/curriculum/T4_Expert/E-DBG-1_Advanced_UVM_Debug_Methodologies/reusable-vip.mdx
@@ -1,17 +1,25 @@
 import { InfoPage } from "@/components/templates/InfoPage";
+import Alert from "@/components/ui/Alert";
 
 export const metadata = {
   title: "Reusable Verification IP (VIP) Architecture | The Professional Verification Craft",
-  description: "...",
+  description: "Patterns for building maintainable verification components.",
 };
 
-<InfoPage
-  title="Reusable Verification IP (VIP) Architecture"
-  uvm_concept_tags={["VIP", "reusable architecture"]}
->
+<InfoPage title="Reusable Verification IP (VIP) Architecture" uvm_concept_tags={["vip","guidelines"]}>
 
-  ## Reusable Verification IP (VIP) Architecture
+## Level 1: Analogy
 
-  This section is under construction. Please check back later.
+Reusable VIP is like a library. Clean interfaces and configuration options let many projects borrow the same component without modification.
+
+## Level 2: Guidelines
+
+- Parameterize widths and protocol options.
+- Use the UVM factory for override flexibility.
+<Alert>Document every sequence and analysis port; future users will thank you.</Alert>
+
+## Level 3: Debug Tips
+
+A well-logged sequence prints transaction summaries using verbosity levels. Turn on `+UVM_OBJECTION_TRACE` when diagnosing lost raises/drops.
 
 </InfoPage>

--- a/content/curriculum/T4_Expert/E-INT-1_Integrating_UVM_with_Formal_Verification/dpi.mdx
+++ b/content/curriculum/T4_Expert/E-INT-1_Integrating_UVM_with_Formal_Verification/dpi.mdx
@@ -2,16 +2,25 @@ import { InfoPage } from "@/components/templates/InfoPage";
 
 export const metadata = {
   title: "Direct Programming Interface (DPI) | The Professional Verification Craft",
-  description: "...",
+  description: "C interoperability for performance and modeling flexibility.",
 };
 
-<InfoPage
-  title="Direct Programming Interface (DPI)"
-  uvm_concept_tags={["DPI"]}
->
+<InfoPage title="Direct Programming Interface (DPI)" uvm_concept_tags={["DPI"]}>
 
-  ## Direct Programming Interface (DPI)
+## Level 1
 
-  This section is under construction. Please check back later.
+The DPI lets SystemVerilog call C functions directly and vice versa. Use it to model complex algorithms or connect to software drivers.
+
+## Level 2
+
+```systemverilog
+import "DPI-C" function int c_add(input int a, input int b);
+```
+
+Call this function from your sequence to reuse proven C code.
+
+## Level 3
+
+Beware of long-running C calls. They block the simulator's time advance and can hide race conditions.
 
 </InfoPage>

--- a/content/curriculum/T4_Expert/E-INT-1_Integrating_UVM_with_Formal_Verification/pss.mdx
+++ b/content/curriculum/T4_Expert/E-INT-1_Integrating_UVM_with_Formal_Verification/pss.mdx
@@ -2,16 +2,21 @@ import { InfoPage } from "@/components/templates/InfoPage";
 
 export const metadata = {
   title: "Introduction to Portable Stimulus (PSS) | The Professional Verification Craft",
-  description: "...",
+  description: "Conceptual overview of portable stimulus methodology.",
 };
 
-<InfoPage
-  title="Introduction to Portable Stimulus (PSS)"
-  uvm_concept_tags={["PSS", "portable stimulus"]}
->
+<InfoPage title="Introduction to Portable Stimulus (PSS)" uvm_concept_tags={["PSS"]}>
 
-  ## Introduction to Portable Stimulus (PSS)
+## Level 1
 
-  This section is under construction. Please check back later.
+PSS describes tests at a higher abstraction so they can run on simulation, emulation, or silicon with minimal changes.
+
+## Level 2
+
+No code needed—think of PSS as a language for expressing scenarios and constraints. Tools generate sequences for different platforms.
+
+## Level 3
+
+While promising, PSS requires tool buy-in and a shift in mindset from test to intent modeling.
 
 </InfoPage>

--- a/content/curriculum/T4_Expert/E-SOC-1_SoC-Level_Verification_Strategies/coverage-closure.mdx
+++ b/content/curriculum/T4_Expert/E-SOC-1_SoC-Level_Verification_Strategies/coverage-closure.mdx
@@ -1,17 +1,34 @@
 import { InfoPage } from "@/components/templates/InfoPage";
+import Alert from "@/components/ui/Alert";
+import Quiz from "@/components/ui/Quiz";
 
 export const metadata = {
   title: "Coverage Closure and Metrics | The Professional Verification Craft",
-  description: "...",
+  description: "Using coverage results to measure verification completeness.",
 };
 
-<InfoPage
-  title="Coverage Closure and Metrics"
-  uvm_concept_tags={["coverage closure", "metrics"]}
->
+<InfoPage title="Coverage Closure and Metrics" uvm_concept_tags={["coverage","metrics"]}>
 
-  ## Coverage Closure and Metrics
+## Level 1: Definition
 
-  This section is under construction. Please check back later.
+Coverage closure means all planned coverage points have been hit and analyzed. It's the signal that testing requirements are satisfied.
+
+## Level 2: Workflow
+
+1. Review coverage reports nightly.
+2. Compare against the V-Plan entries.
+3. Use results to guide new random seeds or directed tests.
+
+<Alert type="warning">Beware of chasing 100% coverage without understanding what each bin represents.</Alert>
+
+<Quiz questions={[{
+  question: "What does a hole in coverage indicate?",
+  options: ["A failing regression", "A scenario not yet observed", "An unconnected DUT port"],
+  correctAnswer: "A scenario not yet observed"
+}]}/>
+
+## Level 3: Expert Notes
+
+Experienced teams automate report parsing to highlight meaningful gaps. They focus effort on coverage items tied to customer requirements rather than trivial toggles.
 
 </InfoPage>

--- a/content/curriculum/T4_Expert/E-SOC-1_SoC-Level_Verification_Strategies/regression-triage.mdx
+++ b/content/curriculum/T4_Expert/E-SOC-1_SoC-Level_Verification_Strategies/regression-triage.mdx
@@ -1,17 +1,32 @@
 import { InfoPage } from "@/components/templates/InfoPage";
+import Alert from "@/components/ui/Alert";
+import Quiz from "@/components/ui/Quiz";
 
 export const metadata = {
   title: "Regression and Triage Strategies | The Professional Verification Craft",
-  description: "...",
+  description: "Building stable regressions and quickly diagnosing failures.",
 };
 
-<InfoPage
-  title="Regression and Triage Strategies"
-  uvm_concept_tags={["regression", "triage"]}
->
+<InfoPage title="Regression and Triage Strategies" uvm_concept_tags={["regression","triage"]}>
 
-  ## Regression and Triage Strategies
+## Level 1: Overview
 
-  This section is under construction. Please check back later.
+A **regression** is a suite of tests run repeatedly (often nightly) to catch new bugs early. **Triage** is the process of analyzing failures to determine root cause.
+
+## Level 2: Best Practices
+
+- Keep a small "smoke" suite for quick checks and a larger nightly run.
+- Store logs and seed numbers with each run for easy reproduction.
+- <Alert>Automate failure categorization—test issue vs DUT bug—so engineers focus on real problems.</Alert>
+
+<Quiz questions={[{
+  question: "What information is most useful when reproducing a failing test?",
+  options: ["Random seed", "Editor theme", "User name"],
+  correctAnswer: "Random seed"
+}]}/>
+
+## Level 3: Anecdote
+
+Veteran teams often rotate "regression sheriff" duty. The sheriff monitors nightly results, files bugs, and ensures fixes are backported before the next run.
 
 </InfoPage>

--- a/src/components/ui/Alert.tsx
+++ b/src/components/ui/Alert.tsx
@@ -1,0 +1,16 @@
+"use client";
+import React from 'react';
+
+interface AlertProps {
+  children: React.ReactNode;
+  type?: 'info' | 'warning';
+}
+
+const Alert: React.FC<AlertProps> = ({ children, type = 'info' }) => {
+  const color = type === 'warning' ? 'bg-yellow-500/10 border-yellow-500' : 'bg-blue-500/10 border-blue-500';
+  return (
+    <div className={`my-4 p-4 border-l-4 ${color} rounded`}> {children} </div>
+  );
+};
+
+export default Alert;

--- a/tests/e2e/module5.spec.ts
+++ b/tests/e2e/module5.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+test('Module 5 InteractiveCode highlights lines', async ({ page }) => {
+  await page.goto('/curriculum/T3_Advanced/A-UVM-5_Advanced_UVM_Techniques');
+  const ic = page.getByTestId('interactive-code').first();
+  await expect(ic).toBeVisible();
+  const codeBlock = ic.locator('pre');
+  await expect(codeBlock).toHaveCSS('overflow-x', 'auto');
+  await ic.getByRole('button', { name: 'Next' }).click();
+  const highlighted = ic.locator('[style*="background-color"]');
+  await expect(highlighted).not.toHaveCount(0);
+});

--- a/tests/sv_examples/coverage_monitor_example.sv
+++ b/tests/sv_examples/coverage_monitor_example.sv
@@ -1,0 +1,11 @@
+class packet; bit [1:0] typ; int size; endclass
+
+class monitor;
+  covergroup cg;
+    cp_type: coverpoint pkt.typ;
+    cp_size: coverpoint pkt.size;
+  endgroup
+  packet pkt;
+  function new(); cg = new(); endfunction
+  function void write(packet p); pkt = p; cg.sample(); endfunction
+endclass

--- a/tests/sv_examples/custom_phase_example.sv
+++ b/tests/sv_examples/custom_phase_example.sv
@@ -1,0 +1,14 @@
+`include "uvm_macros.svh"
+import uvm_pkg::*;
+
+class reset_phase extends uvm_phase;
+  function new(); super.new("reset_phase", UVM_PHASE_SCHEDULE | UVM_PHASE_NODE); endfunction
+  virtual task exec_task(uvm_component c, uvm_phase phase);
+    `uvm_info("RESET", "Applying reset", UVM_LOW)
+  endtask
+endclass
+
+class my_env extends uvm_env;
+  `uvm_component_utils(my_env)
+  function new(string name, uvm_component parent); super.new(name, parent); endfunction
+endclass

--- a/tests/sv_examples/ral_example.sv
+++ b/tests/sv_examples/ral_example.sv
@@ -1,0 +1,49 @@
+`include "uvm_macros.svh"
+import uvm_pkg::*;
+
+class my_reg extends uvm_reg;
+  rand uvm_reg_field f;
+  function new(string name="my_reg");
+    super.new(name, 8, UVM_NO_COVERAGE);
+  endfunction
+  virtual function void build();
+    f = uvm_reg_field::type_id::create("f");
+    f.configure(this, 8, 0, "RW", 0, 0, 1, 0);
+  endfunction
+endclass
+
+class my_reg_block extends uvm_reg_block;
+  rand my_reg r1;
+  function new(string name="my_reg_block");
+    super.new(name, UVM_NO_COVERAGE);
+  endfunction
+  virtual function void build();
+    r1 = my_reg::type_id::create("r1");
+    r1.configure(this, null);
+    r1.build();
+    default_map = create_map("map", 'h0, 4, UVM_LITTLE_ENDIAN);
+    default_map.add_reg(r1, 'h0, "RW");
+  endfunction
+endclass
+
+class my_seq extends uvm_sequence#(uvm_reg_item);
+  my_reg_block model;
+  `uvm_object_utils(my_seq)
+  function new(string name="my_seq"); super.new(name); endfunction
+  virtual task body();
+    uvm_status_e status;
+    model.r1.write(status, 'hAA, UVM_FRONTDOOR);
+    model.r1.write(status, 'h55, UVM_BACKDOOR);
+  endtask
+endclass
+
+class my_predictor extends uvm_reg_predictor;
+  `uvm_component_utils(my_predictor)
+  function new(string name, uvm_component parent);
+    super.new(name, parent);
+  endfunction
+  virtual function void write(uvm_reg_bus_op rw);
+    rw.data = ~rw.data;
+    super.write(rw);
+  endfunction
+endclass

--- a/tests/sv_examples/uvm/uvm_macros.svh
+++ b/tests/sv_examples/uvm/uvm_macros.svh
@@ -1,0 +1,2 @@
+`define uvm_object_utils(x)
+`define uvm_component_utils(x)

--- a/tests/sv_examples/uvm/uvm_pkg.sv
+++ b/tests/sv_examples/uvm/uvm_pkg.sv
@@ -1,0 +1,14 @@
+package uvm_pkg;
+  class uvm_object; endclass
+  class uvm_component; endclass
+  class uvm_reg; endclass
+  class uvm_reg_field; endclass
+  class uvm_reg_block; endclass
+  class uvm_sequence_item; endclass
+  class uvm_sequence #(type T=int); endclass
+  class uvm_sequencer #(type T=int); endclass
+  class uvm_phase; endclass
+  class uvm_reg_item; endclass
+  class uvm_reg_predictor; endclass
+  typedef int uvm_status_e;
+endpackage

--- a/tests/sv_examples/virtual_sequence_example.sv
+++ b/tests/sv_examples/virtual_sequence_example.sv
@@ -1,0 +1,36 @@
+`include "uvm_macros.svh"
+import uvm_pkg::*;
+
+class simple_seq extends uvm_sequence#(int);
+  int value;
+  `uvm_object_utils(simple_seq)
+  function new(string name="simple_seq"); super.new(name); endfunction
+  virtual task body();
+    `uvm_info(get_type_name(), $sformatf("Running seq with value %0d", value), UVM_LOW)
+  endtask
+endclass
+
+class top_virtual_seq extends uvm_sequence;
+  `uvm_object_utils(top_virtual_seq)
+  simple_seq seqA;
+  simple_seq seqB;
+  virtual task body();
+    seqA = simple_seq::type_id::create("seqA"); seqA.value = 1;
+    seqB = simple_seq::type_id::create("seqB"); seqB.value = 2;
+    p_sequencer.seqrA.lock(this);
+    fork
+      seqA.start(p_sequencer.seqrA);
+      seqB.start(p_sequencer.seqrB);
+    join
+    p_sequencer.seqrA.unlock(this);
+  endtask
+endclass
+
+class virtual_sequencer extends uvm_sequencer;
+  `uvm_component_utils(virtual_sequencer)
+  uvm_sequencer #(int) seqrA;
+  uvm_sequencer #(int) seqrB;
+  function new(string name, uvm_component parent);
+    super.new(name, parent);
+  endfunction
+endclass


### PR DESCRIPTION
## Summary
- populate Module 5 advanced UVM techniques page with RAL, sequencing, custom phases and coverage monitor examples
- flesh out Module 6 professional craft pages with planning, regression, VIP and interoperability material
- add simple Alert component for callouts
- include Playwright test for Module 5 InteractiveCode
- add SystemVerilog snippet files for syntax checking attempts

## Testing
- `npm install`
- `npm test` *(fails: Error fetching prisma engine checksum due to network restrictions)*
- `verilator --lint-only -Itests/sv_examples/uvm tests/sv_examples/coverage_monitor_example.sv` *(fails: covergroup unsupported)*

------
https://chatgpt.com/codex/tasks/task_e_6881baee7a7883308f8d1973e9872741