### PR TITLE
Finalize responsive design and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **Vision:** To be the world's leading open-source, curriculum-based guide for SystemVerilog and UVM.
 
+**Tagline:** *The definitive online resource for mastering SystemVerilog and UVM.*
+
 This repository provides a structured and comprehensive curriculum for learning SystemVerilog and the Universal Verification Methodology (UVM). Our goal is to create a platform that is accessible to beginners, yet deep enough for experienced engineers to hone their skills.
 
 ## Curriculum Architecture
@@ -22,3 +24,34 @@ The curriculum is organized into a four-tiered structure, based on the principle
 If you are new to SystemVerilog and verification, we recommend starting with the first module of Tier 1:
 
 [/T1_Foundational/F1_Why_Verification/](/T1_Foundational/F1_Why_Verification/)
+
+## Deployment
+
+The site uses Next.js with a standalone output so it can be hosted on most platforms.
+
+### Local Production Build
+
+```bash
+npm run build
+npm start
+```
+
+### Docker
+
+```bash
+docker build -t sv-uvm-guide .
+docker run -p 3000:3000 sv-uvm-guide
+```
+
+### Vercel
+
+Deploying via Vercel works out of the box using the `next start` command. The `output: 'standalone'` setting keeps image size small.
+
+If exporting with `next export`, guard any `window` usage as it only runs client-side.
+
+## Phase Deliverables
+
+* [Enhancement Blueprint](enhance.md)
+* [Planned Enhancements](enhancements.md)
+
+Contributions are welcome via pull requests. See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -60,6 +60,14 @@ const calSans = localFont({
 export const metadata: Metadata = {
   title: "SystemVerilog & UVM Mastery",
   description: "The definitive online platform for mastering SystemVerilog and UVM.",
+  openGraph: {
+    title: "SystemVerilog & UVM Mastery",
+    description: "The definitive online platform for mastering SystemVerilog and UVM.",
+    url: "https://example.com",
+    siteName: "SV/UVM Hub",
+    locale: "en_US",
+    type: "website",
+  },
 };
 
 interface RootLayoutProps {

--- a/src/components/InteractiveUvmDiagram.tsx
+++ b/src/components/InteractiveUvmDiagram.tsx
@@ -3,7 +3,7 @@ import { motion } from 'framer-motion';
 
 const InteractiveUvmDiagram = () => {
   return (
-    <svg width="800" height="600" viewBox="0 0 850 650" xmlns="http://www.w3.org/2000/svg" fontFamily="Arial, sans-serif" fontSize="14px">
+    <svg className="w-full h-auto" viewBox="0 0 850 650" xmlns="http://www.w3.org/2000/svg" fontFamily="Arial, sans-serif" fontSize="14px" role="img" aria-label="UVM component interactions diagram">
       <style>
         {`
           .block { stroke: hsl(var(--primary)); stroke-width: 1.5; fill: hsl(var(--primary-foreground)); }

--- a/src/components/diagrams/AnimatedUvmSequenceDriverHandshakeDiagram.tsx
+++ b/src/components/diagrams/AnimatedUvmSequenceDriverHandshakeDiagram.tsx
@@ -38,7 +38,7 @@ const AnimatedUvmSequenceDriverHandshakeDiagram: React.FC = () => {
 
   return (
     <div style={{ textAlign: 'center', fontFamily: 'Arial, sans-serif' }}>
-      <svg width="800" height={lifelineHeight + 100} viewBox={`0 0 800 ${lifelineHeight + 100}`}>
+      <svg className="w-full h-auto" height={lifelineHeight + 100} viewBox={`0 0 800 ${lifelineHeight + 100}`} role="img" aria-label="UVM sequence-driver handshake diagram"> 
         {/* Participants and Lifelines */}
         {participants.map(p => (
           <g key={p.id}>

--- a/src/components/diagrams/AnimatedUvmTestbenchDiagram.tsx
+++ b/src/components/diagrams/AnimatedUvmTestbenchDiagram.tsx
@@ -29,7 +29,7 @@ const AnimatedUvmTestbenchDiagram: React.FC = () => {
   const [hoveredComponent, setHoveredComponent] = useState<string | null>(null);
 
   return (
-    <svg width="600" height="650" viewBox="0 0 600 650" style={{ border: '1px solid #ccc', borderRadius: '8px' }}>
+    <svg className="w-full h-auto" viewBox="0 0 600 650" style={{ border: '1px solid #ccc', borderRadius: '8px' }} role="img" aria-label="Animated UVM testbench diagram">
       {/* Connection Lines */}
       {connections.map((conn, index) => {
         const fromComponent = components.find(c => c.id === conn.from);

--- a/src/components/diagrams/UvmVirtualSequencerDiagram.tsx
+++ b/src/components/diagrams/UvmVirtualSequencerDiagram.tsx
@@ -22,7 +22,7 @@ const connections = [
 const UvmVirtualSequencerDiagram: React.FC = () => {
   return (
     <div style={{ textAlign: 'center', fontFamily: 'Arial, sans-serif' }}>
-      <svg width="800" height="400" viewBox="0 0 800 400">
+      <svg className="w-full h-auto" viewBox="0 0 800 400" role="img" aria-label="UVM virtual sequencer diagram">
         {/* Participants */}
         {participants.map(p => (
           <g key={p.id}>

--- a/src/components/exercises/ScoreboardConnectorExercise.tsx
+++ b/src/components/exercises/ScoreboardConnectorExercise.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useRef, MouseEvent } from 'react';
+import { Button } from '@/components/ui/Button';
 
 interface Port {
   id: string;

--- a/src/components/ui/CodeBlock.tsx
+++ b/src/components/ui/CodeBlock.tsx
@@ -85,22 +85,24 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
             </Button>
          </div>
       )}
-      <SyntaxHighlighter
-        language={language.toLowerCase() === "systemverilog" ? "verilog" : language}
-        style={codeTheme}
-        showLineNumbers={showLineNumbers}
-        lineNumberStyle={{ color: "var(--muted-foreground)", fontSize: "0.8em", marginRight: "1em" }}
-        wrapLines={true}
-        lineProps={lineProps}
-        customStyle={{
-          margin: 0,
-          borderRadius: "0",
-          backgroundColor: "transparent",
-          ...customStyle,
-        }}
-      >
-        {code.trim()}
-      </SyntaxHighlighter>
+      <div className="overflow-x-auto">
+        <SyntaxHighlighter
+          language={language.toLowerCase() === "systemverilog" ? "verilog" : language}
+          style={codeTheme as any}
+          showLineNumbers={showLineNumbers}
+          lineNumberStyle={{ color: "var(--muted-foreground)", fontSize: "0.8em", marginRight: "1em" }}
+          wrapLines={true}
+          lineProps={lineProps}
+          customStyle={{
+            margin: 0,
+            borderRadius: "0",
+            backgroundColor: "transparent",
+            ...customStyle,
+          }}
+        >
+          {code.trim()}
+        </SyntaxHighlighter>
+      </div>
     </div>
   );
 };

--- a/src/components/ui/Logo.tsx
+++ b/src/components/ui/Logo.tsx
@@ -5,9 +5,9 @@ const Logo = () => {
     <svg
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 100 20"
-      width="150"
-      height="40"
-      className="text-accent"
+      className="text-accent w-full max-w-[150px] h-auto"
+      role="img"
+      aria-label="SV/UVM Hub logo"
     >
       <text
         x="0"


### PR DESCRIPTION
## Summary
- document deployment instructions and tagline
- wrap code blocks in a scrollable container
- make all SVG diagrams responsive and accessible
- add open graph SEO metadata
- fix lint issue in `ScoreboardConnectorExercise`

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test` *(fails: Failed to fetch sha256 checksum at binaries.prisma.sh)*

------
https://chatgpt.com/codex/tasks/task_e_6881bbaae5f883309f3c4c5645de8ae9