### PR TITLE
Add quiz test, flashcards, and cross-link script

### DIFF
--- a/content/curriculum/T2_Intermediate/I-UVM-3_Sequences/index.mdx
+++ b/content/curriculum/T2_Intermediate/I-UVM-3_Sequences/index.mdx
@@ -4,6 +4,7 @@ description: "Mastering the core of UVM's powerful stimulus generation methodolo
 ---
 
 import { Quiz, InteractiveCode, Panel } from '/src/components/ui/index.js'
+import Link from 'next/link'
 import { AnimatedUvmSequenceDriverHandshakeDiagram } from '/src/components/diagrams/AnimatedUvmSequenceDriverHandshakeDiagram.tsx'
 
 ## The "Why" of Sequences
@@ -94,6 +95,8 @@ module top;
 endmodule
 ```
 </InteractiveCode>
+
+This example registers the default sequence using <Link href="/curriculum/T2_Intermediate/I-UVM-3_Sequences/uvm-config-db">uvm_config_db</Link> so the sequencer can retrieve it at runtime.
 
 ### Procedural Sequences
 

--- a/content/flashcards/F2_HDL_Primer.json
+++ b/content/flashcards/F2_HDL_Primer.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "hdl1",
+    "question": "What hardware elements store state in digital designs?",
+    "answer": "Flip-flops"
+  },
+  {
+    "id": "hdl2",
+    "question": "Which HDL is used throughout this course?",
+    "answer": "SystemVerilog"
+  },
+  {
+    "id": "hdl3",
+    "question": "What design pattern uses states like Green, Yellow, and Red?",
+    "answer": "Finite State Machine"
+  }
+]

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "type-check": "tsc --noEmit",
     "test": "playwright test",
     "test:e2e": "SESSION_SECRET=dummy_secret_for_testing_purposes npx playwright test",
+    "crosslink": "node scripts/crosslink.cjs",
     "clean-and-run": "rm -rf .next && rm -rf node_modules && npm install && npm run dev"
   },
   "dependencies": {
@@ -72,6 +73,7 @@
     "prisma": "^6.12.0",
     "tailwindcss": "^3.4.3",
     "typescript": "5.8.3",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "ts-node": "^10.9.1"
   }
 }

--- a/scripts/crosslink.cjs
+++ b/scripts/crosslink.cjs
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+
+const mappings = {
+  uvm_config_db: '/curriculum/T2_Intermediate/I-UVM-3_Sequences/uvm-config-db',
+  randc: '/curriculum/T2_Intermediate/I-SV-2_Constrained_Randomization',
+};
+
+function processFile(filePath) {
+  let content = fs.readFileSync(filePath, 'utf8');
+  for (const term of Object.keys(mappings)) {
+    const link = mappings[term];
+    const regex = new RegExp(`\\b${term}\\b`);
+    if (regex.test(content)) {
+      content = content.replace(regex, `<Link href="${link}">${term}</Link>`);
+      break;
+    }
+  }
+  fs.writeFileSync(filePath, content, 'utf8');
+}
+
+function walk(dir) {
+  for (const entry of fs.readdirSync(dir)) {
+    const p = path.join(dir, entry);
+    if (fs.statSync(p).isDirectory()) walk(p);
+    else if (p.endsWith('.mdx')) processFile(p);
+  }
+}
+
+walk(path.join(process.cwd(), 'content', 'curriculum'));

--- a/tests/quiz.spec.tsx
+++ b/tests/quiz.spec.tsx
@@ -1,0 +1,25 @@
+import { render, fireEvent, screen } from '@testing-library/react';
+import Quiz from '../src/components/ui/Quiz';
+import React from 'react';
+
+describe('Quiz component', () => {
+  const questions = [
+    {
+      question: '2 + 2 = ?',
+      options: ['3', '4'],
+      correctAnswer: '4',
+    },
+  ];
+
+  it('shows Correct! when selecting the right answer', () => {
+    render(<Quiz questions={questions} />);
+    fireEvent.click(screen.getByText('4'));
+    screen.getByText('Correct!');
+  });
+
+  it('shows Incorrect. when selecting the wrong answer', () => {
+    render(<Quiz questions={questions} />);
+    fireEvent.click(screen.getByText('3'));
+    screen.getByText('Incorrect.');
+  });
+});


### PR DESCRIPTION
## Summary
- create F2_HDL_Primer flashcards dataset
- enable a cross-link in UVM sequences content
- add cross-link utility script and npm script
- add unit test for Quiz component

## Testing
- `npm run crosslink`
- `npm run lint` *(fails: 'Button' is not defined)*
- `npm run build` *(fails: Button not defined)*
- `npm test` *(fails to fetch Prisma engine)*

------
https://chatgpt.com/codex/tasks/task_e_6881bb7173148330b93187561aeadcb3