### PR TITLE
Fix component imports

### DIFF
--- a/src/app/curriculum/[...slug]/page.tsx
+++ b/src/app/curriculum/[...slug]/page.tsx
@@ -18,7 +18,7 @@ import { AnimatedUvmSequenceDriverHandshakeDiagram } from '@/components/diagrams
 import DataTypeComparisonChart from '@/components/charts/DataTypeComparisonChart';
 import UvmHierarchySunburstChart from '@/components/charts/UvmHierarchySunburstChart';
 import UvmPhasingDiagram from '@/components/diagrams/UvmPhasingDiagram';
-import { DiagramPlaceholder} from '@/components/templates/InfoPage';
+import { DiagramPlaceholder, InteractiveChartPlaceholder } from '@/components/templates/InfoPage';
 import AnimatedUvmTestbenchDiagram from '@/components/diagrams/AnimatedUvmTestbenchDiagram';
 import { Alert } from '@/components/ui/Alert';
 import UvmVirtualSequencerDiagram from '@/components/diagrams/UvmVirtualSequencerDiagram';

--- a/src/components/ui/Alert.tsx
+++ b/src/components/ui/Alert.tsx
@@ -13,4 +13,5 @@ const Alert: React.FC<AlertProps> = ({ children, type = 'info' }) => {
   );
 };
 
+export { Alert };
 export default Alert;


### PR DESCRIPTION
## Summary
- export `Alert` as a named component
- import `InteractiveChartPlaceholder` in curriculum page

## Testing
- `npm test` *(fails: Failed to fetch Prisma binaries)*

------
https://chatgpt.com/codex/tasks/task_e_6884a4965d8883308ba3bf87ad655439