### PR TITLE
Fix MDX quiz links and update test path

### DIFF
--- a/content/curriculum/T1_Foundational/F3_Procedural_Constructs/index.mdx
+++ b/content/curriculum/T1_Foundational/F3_Procedural_Constructs/index.mdx
@@ -78,7 +78,7 @@ end
         {"text": "`always`", "correct": false},
         {"text": "`initial`", "correct": true},
         {"text": "`final`", "correct": false},
-        {"text": "`<Link href="/curriculum/T1_Foundational/F3_Procedural_Constructs/fork-join">fork-join</Link>`", "correct": false}
+        {"text": "fork-join", "correct": false}
       ],
       "explanation": "`initial` blocks are used for initialization tasks that only need to be performed once at the beginning of a simulation."
     }

--- a/content/curriculum/T3_Advanced/A-UVM-1_Advanced_Sequencing/virtual-sequences.mdx
+++ b/content/curriculum/T3_Advanced/A-UVM-1_Advanced_Sequencing/virtual-sequences.mdx
@@ -77,7 +77,7 @@ endclass
 `}
   explanationSteps={[
     { target: "2-10", title: "Virtual Sequencer Class", explanation: "The `virtual_sequencer` is a standard `uvm_sequencer`. It doesn't have a type parameter because it doesn't handle a specific transaction type." },
-    { target: "5-6", title: "Sequencer Handles", explanation: "It contains handles to the real sequencers in the testbench, in this case, `m_pci_sequencer` and `m_eth_sequencer`. These handles are typically assigned using `<Link href="/curriculum/T2_Intermediate/I-UVM-3_Sequences/uvm-config-db">uvm_config_db</Link>` in the environment." },
+    { target: "5-6", title: "Sequencer Handles", explanation: "It contains handles to the real sequencers in the testbench, in this case, `m_pci_sequencer` and `m_eth_sequencer`. These handles are typically assigned using uvm_config_db in the environment." },
     { target: "13-35", title: "Virtual Sequence Class", explanation: "The `virtual_sequence` runs on the `virtual_sequencer`. Its purpose is to start and coordinate other sequences on the agent-specific sequencers." },
     { target: "17", title: "Sequencer Pointer", explanation: "It's good practice to have a typed pointer `p_sequencer` to the virtual sequencer for easier access to its members." },
     { target: "23-25", title: "Getting the Sequencer Handle", explanation: "In the `body` task, we get the typed pointer to the virtual sequencer using `$cast`. The `m_sequencer` handle is a generic `uvm_sequencer` handle available in all sequences." },

--- a/content/curriculum/T3_Advanced/A-UVM-2_The_UVM_Factory_In-Depth/index.mdx
+++ b/content/curriculum/T3_Advanced/A-UVM-2_The_UVM_Factory_In-Depth/index.mdx
@@ -72,7 +72,7 @@ This will print a detailed report of all the factory's registered types, overrid
       "answers": [
         {"text": "A type override", "correct": false},
         {"text": "An instance override", "correct": true},
-        {"text": "A `<Link href="/curriculum/T2_Intermediate/I-UVM-3_Sequences/uvm-config-db">uvm_config_db</Link>` set", "correct": false},
+        {"text": "A uvm_config_db set", "correct": false},
         {"text": "A sequence override", "correct": false}
       ],
       "explanation": "An instance override allows you to target a specific component by its hierarchical path (e.g., `env.agent1.*`), providing the precision needed for this scenario."

--- a/content/curriculum/uvm-core/fundamentals/factory.mdx
+++ b/content/curriculum/uvm-core/fundamentals/factory.mdx
@@ -115,7 +115,7 @@ endclass
       "answers": [
         {"text": "A type override", "correct": false},
         {"text": "An instance override", "correct": true},
-        {"text": "A `<Link href="/curriculum/T2_Intermediate/I-UVM-3_Sequences/uvm-config-db">uvm_config_db</Link>` set", "correct": false},
+        {"text": "A uvm_config_db set", "correct": false},
         {"text": "A sequence override", "correct": false}
       ],
       "explanation": "An instance override allows you to target a specific component by its hierarchical path (e.g., `env.agent1.*`), providing the precision needed for this scenario."

--- a/tests/e2e/module5.spec.ts
+++ b/tests/e2e/module5.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('Module 5 InteractiveCode highlights lines', async ({ page }) => {
-  await page.goto('/curriculum/T3_Advanced/A-UVM-5_Advanced_UVM_Techniques');
+  await page.goto('/curriculum/T3_Advanced/A-UVM-3_Advanced_UVM_Techniques');
   const ic = page.getByTestId('interactive-code').first();
   await expect(ic).toBeVisible();
   const codeBlock = ic.locator('pre');


### PR DESCRIPTION
## Summary
- fix invalid `<Link>` strings in MDX quiz content
- update advanced sequencing explanations
- adjust advanced factory quiz answers
- correct module 5 test path for advanced techniques

## Testing
- `npm test` *(fails: Error: Process from config.webServer was not able to start)*

------
https://chatgpt.com/codex/tasks/task_e_6884a78d02f883309e277d3c353b9001