### PR TITLE
feat: Create New Module A2 – Scoreboards and Functional Coverage in UVM

### DIFF
--- a/docs/T3_Advanced/A2_Scoreboards_and_Coverage.md
+++ b/docs/T3_Advanced/A2_Scoreboards_and_Coverage.md
@@ -1,0 +1,226 @@
+---
+sidebar_label: 'A2 - Scoreboards and Functional Coverage'
+sidebar_position: 2
+---
+
+# A2 – Scoreboards and Functional Coverage in UVM
+
+A testbench that only generates stimulus is incomplete. The true power of a UVM environment lies in its ability to automatically check the DUT's behavior and measure how thoroughly it has been tested. This module covers two critical components for achieving this: the Scoreboard and the Functional Coverage collector.
+
+## 1. The UVM Scoreboard: Your Automated Test Checker
+
+The scoreboard is the brain of a self-checking testbench. Its primary role is to verify the functional correctness of the DUT.
+
+**Purpose of the Scoreboard:**
+
+1.  **Receive Inputs**: It collects transaction data observed by the input monitor(s).
+2.  **Predict Behavior**: It uses a functional model (often called a reference model) to predict the expected output of the DUT based on the inputs it received.
+3.  **Receive Actual Outputs**: It collects the actual output transactions observed by the output monitor(s).
+4.  **Compare and Verify**: It compares the predicted output with the actual output and flags an error if there is a mismatch.
+
+### Connecting the Scoreboard
+
+A scoreboard uses `uvm_analysis_imp` ports to receive data from monitors. An `imp` port is a standard TLM port designed to be implemented by the component that receives the data.
+
+In the environment's `connect_phase`, you connect the monitor's analysis port to the scoreboard's analysis export.
+
+```systemverilog
+// In the environment's connect_phase
+// Connect input monitor to scoreboard
+m_agent.m_monitor.item_collected_port.connect(m_scoreboard.input_analysis_export);
+
+// Connect output monitor to scoreboard
+m_output_monitor.item_collected_port.connect(m_scoreboard.output_analysis_export);
+```
+
+### Data Structures for Synchronization
+
+A key challenge is that the input transaction and its corresponding output transaction may not arrive at the scoreboard at the same time. There is often latency through the DUT. The scoreboard needs a way to store incoming transactions until it has all the pieces needed for a comparison.
+
+Common data structures for this include:
+
+-   **`uvm_tlm_analysis_fifo`**: A specialized FIFO provided by UVM that has a `uvm_analysis_export` for receiving data. It's a simple, convenient way to queue up transactions.
+-   **Queues (`$`)**: A standard SystemVerilog queue can be used to store transactions.
+-   **Associative Arrays**: Useful when you need to match specific transactions, for example, by using a transaction ID as the key.
+
+### Implementation Logic
+
+Let's build a scoreboard for our ALU testbench.
+
+1.  **Class Definition**: Create a `scoreboard` class that extends `uvm_scoreboard`.
+
+    ```systemverilog
+    class scoreboard extends uvm_scoreboard;
+      `uvm_component_utils(scoreboard)
+
+      // Analysis exports to receive transactions from monitors
+      uvm_analysis_imp #(alu_transaction, scoreboard) input_analysis_export;
+      uvm_analysis_imp #(alu_transaction, scoreboard) output_analysis_export;
+
+      // Internal FIFOs to store the transactions
+      uvm_tlm_analysis_fifo #(alu_transaction) input_fifo;
+      uvm_tlm_analysis_fifo #(alu_transaction) output_fifo;
+
+      // ...
+    endclass
+    ```
+
+2.  **`build_phase`**: In the `build_phase`, create the analysis exports and the internal FIFOs.
+
+    ```systemverilog
+    function void build_phase(uvm_phase phase);
+      super.build_phase(phase);
+      input_analysis_export = new("input_analysis_export", this);
+      output_analysis_export = new("output_analysis_export", this);
+      input_fifo = new("input_fifo", this);
+      output_fifo = new("output_fifo", this);
+    endfunction
+    ```
+
+3.  **`connect_phase`**: In the scoreboard's `connect_phase`, connect the `imp` ports to the FIFOs. This is a common pattern: the scoreboard's public-facing port simply passes the transaction to an internal component (the FIFO).
+
+    ```systemverilog
+    function void connect_phase(uvm_phase phase);
+      input_analysis_export.connect(input_fifo.analysis_export);
+      output_analysis_export.connect(output_fifo.analysis_export);
+    endfunction
+    ```
+
+4.  **`run_phase`**: This is where the checking logic resides. The task will run forever, pulling transactions from both FIFOs, predicting the result, and comparing.
+
+    ```systemverilog
+    task run_phase(uvm_phase phase);
+      alu_transaction input_tx, output_tx;
+      alu_transaction expected_tx;
+
+      forever begin
+        // Block until one transaction is available from both input and output
+        input_fifo.get(input_tx);
+        output_fifo.get(output_tx);
+
+        `uvm_info("SCOREBOARD", $sformatf("Checking transaction: op=%s, a=%0h, b=%0h",
+                  input_tx.op.name(), input_tx.a, input_tx.b), UVM_HIGH)
+
+        // 1. Predict
+        expected_tx = new();
+        predict_result(input_tx, expected_tx);
+
+        // 2. Compare
+        if (!expected_tx.compare(output_tx)) begin
+          `uvm_error("SCOREBOARD_MISMATCH", $sformatf("Scoreboard check FAILED. Expected: %s, Actual: %s",
+                     expected_tx.convert2string(), output_tx.convert2string()))
+        end else begin
+          `uvm_info("SCOREBOARD_MATCH", "Scoreboard check PASSED.", UVM_HIGH)
+        end
+      end
+    endtask
+
+    // The reference model
+    function void predict_result(alu_transaction in_tx, ref alu_transaction out_tx);
+      out_tx.op = in_tx.op;
+      case (in_tx.op)
+        ADD: out_tx.result = in_tx.a + in_tx.b;
+        SUB: out_tx.result = in_tx.a - in_tx.b;
+        MUL: out_tx.result = in_tx.a * in_tx.b;
+        // Assume DIV is not supported for simplicity
+        default: out_tx.result = 'x;
+      endcase
+    endfunction
+    ```
+
+## 2. UVM Functional Coverage
+
+Functional coverage answers the question, "Have I tested all the interesting scenarios and corner cases?" It's a user-defined metric that measures how well the verification plan has been exercised.
+
+### Integrating `covergroup`
+
+The best place to sample coverage is in a component that *observes* the behavior of the DUT and the testbench—typically a **monitor** or a dedicated **coverage collector**. This component has access to the transactions that represent the actual stimulus applied and the results produced.
+
+### `uvm_subscriber`: A Component for Analysis
+
+While you can place a `covergroup` directly in a monitor or scoreboard, a cleaner approach is to create a dedicated component for coverage collection. UVM provides `uvm_subscriber` for this exact purpose.
+
+A `uvm_subscriber` is a `uvm_component` that comes pre-packaged with a `uvm_analysis_imp` port called `analysis_export`. Its sole purpose is to receive transactions and perform some analysis on them, like sampling a `covergroup`.
+
+### Implementation
+
+1.  **Create `coverage_collector.sv`**: Define a class that extends `uvm_subscriber` and is parameterized with the transaction type.
+
+    ```systemverilog
+    class coverage_collector extends uvm_subscriber #(alu_transaction);
+      `uvm_component_utils(coverage_collector)
+
+      // The covergroup definition
+      covergroup alu_op_cg;
+        option.per_instance = 1;
+        OP_CP: coverpoint trans.op;
+      endgroup
+
+      function new(string name = "coverage_collector", uvm_component parent = null);
+        super.new(name, parent);
+        alu_op_cg = new();
+      endfunction
+
+      // This function is automatically called when a transaction is written to the subscriber
+      function void write(alu_transaction t);
+        `uvm_info("COVERAGE", "Sampling transaction in covergroup", UVM_HIGH)
+        alu_op_cg.sample();
+      endfunction
+    endclass
+    ```
+
+2.  **Instantiate and Connect**: In the environment, create an instance of the `coverage_collector` and connect the monitor's analysis port to it.
+
+    ```systemverilog
+    // In alu_env.sv build_phase
+    m_coverage = coverage_collector::type_id::create("m_coverage", this);
+
+    // In alu_env.sv connect_phase
+    m_agent.m_monitor.item_collected_port.connect(m_coverage.analysis_export);
+    ```
+
+### Controlling and Checking Coverage
+
+-   **Instance vs. Type Coverage**: By default (`option.per_instance = 1`), each instance of your coverage collector will have its own coverage statistics. This is usually what you want.
+-   **Checking Coverage Goals**: In the `report_phase` of your test, you can check if your coverage goals have been met.
+
+    ```systemverilog
+    // In the test's report_phase
+    function void report_phase(uvm_phase phase);
+      super.report_phase(phase);
+      real cvg = m_env.m_coverage.alu_op_cg.get_inst_coverage();
+      `uvm_info("COVERAGE_REPORT", $sformatf("ALU Operations coverage is: %2.2f%%", cvg), UVM_LOW)
+      if (cvg < 100.0) begin
+        `uvm_warning("LOW_COVERAGE", "ALU Operations coverage goal not met!")
+      end
+    endfunction
+    ```
+
+## 3. Putting It Together: Updating the ALU Testbench
+
+Now, let's update the testbench from `tests/I4_alu_uvm_testbench/` to incorporate these new components.
+
+**(The full code for each updated file will be shown in collapsible sections).**
+
+### Case Study: How a Scoreboard Catches a Bug
+
+Imagine a subtle bug is introduced into the ALU's RTL:
+
+```systemverilog
+// Buggy RTL for subtraction
+assign result = (op == SUB) ? (a - b - 1) : (a - b); // Off-by-one error
+```
+
+Without a scoreboard, this bug might go unnoticed. A test might run to completion, waves might look "reasonable" at a glance, and no errors would be reported.
+
+**How the scoreboard finds it:**
+
+1.  **Stimulus**: A sequence sends a transaction: `op=SUB, a=10, b=5`.
+2.  **Monitor**: The input monitor captures this transaction and sends it to the scoreboard.
+3.  **Scoreboard Prediction**: The scoreboard's `predict_result` function calculates the expected result: `10 - 5 = 5`.
+4.  **DUT Execution**: The buggy DUT calculates `10 - 5 - 1 = 4`.
+5.  **Monitor**: The output monitor captures the actual result: `result=4`.
+6.  **Scoreboard Comparison**: The scoreboard's `run_phase` pulls the input transaction (a=10, b=5) and the output transaction (result=4). It compares its predicted result (5) with the actual result (4).
+7.  **ERROR!**: The `compare()` function fails. The scoreboard reports a `UVM_ERROR`, pinpointing the exact transaction that failed and showing the difference between the expected and actual values. The test now fails, immediately alerting the engineer to the bug.
+
+This case study highlights the power of a self-checking testbench. By automating the verification process, scoreboards can catch bugs that are difficult to spot with manual inspection, leading to more robust and reliable designs.

--- a/src/lib/curriculum-data.ts
+++ b/src/lib/curriculum-data.ts
@@ -203,6 +203,13 @@ export const curriculumData: Module[] = [
             topics: [
                 { title: "UVM Sequences and Virtual Sequences", slug: "index", description: "In-depth guide to UVM sequence mechanics, layering, and the use of virtual sequences." },
             ]
+          },
+          {
+            title: "Scoreboards and Functional Coverage in UVM",
+            slug: "A2_Scoreboards_and_Coverage",
+            topics: [
+                { title: "Scoreboards and Functional Coverage in UVM", slug: "index", description: "Explain how to design and implement a UVM scoreboard for automated, self-checking tests." },
+            ]
           }
       ]
   },

--- a/tests/I4_alu_uvm_testbench/alu.sv
+++ b/tests/I4_alu_uvm_testbench/alu.sv
@@ -1,9 +1,20 @@
-module alu (alu_if.DUT alu_port);
-  always_comb begin
-    case (alu_port.opcode)
-      ADD: alu_port.y = alu_port.a + alu_port.b;
-      SUB: alu_port.y = alu_port.a - alu_port.b;
-      default: alu_port.y = 'x;
+module alu(
+  input [7:0] a,
+  input [7:0] b,
+  input [3:0] op,
+  output logic [7:0] result,
+  input start,
+  output logic done
+);
+
+  always @(posedge start) begin
+    case (op)
+      0: result <= a + b;
+      1: result <= a - b;
+      2: result <= a * b;
+      default: result <= 'x;
     endcase
+    done <= 1;
   end
+
 endmodule

--- a/tests/I4_alu_uvm_testbench/alu_agent.sv
+++ b/tests/I4_alu_uvm_testbench/alu_agent.sv
@@ -1,8 +1,9 @@
 class alu_agent extends uvm_agent;
   `uvm_component_utils(alu_agent)
 
-  alu_driver drv;
-  alu_monitor mon;
+  alu_driver m_driver;
+  alu_monitor m_monitor;
+  uvm_sequencer #(alu_transaction) m_sequencer;
 
   function new(string name = "alu_agent", uvm_component parent = null);
     super.new(name, parent);
@@ -10,13 +11,14 @@ class alu_agent extends uvm_agent;
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
-    drv = alu_driver::type_id::create("drv", this);
-    mon = alu_monitor::type_id::create("mon", this);
+    m_driver = alu_driver::type_id::create("m_driver", this);
+    m_monitor = alu_monitor::type_id::create("m_monitor", this);
+    m_sequencer = uvm_sequencer #(alu_transaction)::type_id::create("m_sequencer", this);
   endfunction
 
   function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);
-    drv.seq_item_port.connect(seq_item_export);
-    mon.analysis_port.connect(this.analysis_port);
+    m_driver.seq_item_port.connect(m_sequencer.seq_item_export);
+    m_monitor.item_collected_port.connect(this.analysis_port);
   endfunction
 endclass

--- a/tests/I4_alu_uvm_testbench/alu_base_sequence.sv
+++ b/tests/I4_alu_uvm_testbench/alu_base_sequence.sv
@@ -6,10 +6,10 @@ class alu_base_sequence extends uvm_sequence #(alu_transaction);
   endfunction
 
   virtual task body();
-    alu_transaction req;
-    req = alu_transaction::type_id::create("req");
-    start_item(req);
-    assert(req.randomize());
-    finish_item(req);
+    repeat (10) begin
+      `uvm_do_with(alu_transaction, { op == ADD; })
+      `uvm_do_with(alu_transaction, { op == SUB; })
+      `uvm_do_with(alu_transaction, { op == MUL; })
+    end
   endtask
 endclass

--- a/tests/I4_alu_uvm_testbench/alu_driver.sv
+++ b/tests/I4_alu_uvm_testbench/alu_driver.sv
@@ -16,10 +16,12 @@ class alu_driver extends uvm_driver #(alu_transaction);
   virtual task run_phase(uvm_phase phase);
     forever begin
       seq_item_port.get_next_item(req);
-      vif.a <= req.a;
-      vif.b <= req.b;
-      vif.opcode <= req.opcode;
-      #10;
+      vif.driver_cb.start <= 1;
+      vif.driver_cb.a <= req.a;
+      vif.driver_cb.b <= req.b;
+      vif.driver_cb.op <= req.op;
+      @(vif.driver_cb);
+      vif.driver_cb.start <= 0;
       seq_item_port.item_done();
     end
   endtask

--- a/tests/I4_alu_uvm_testbench/alu_env.sv
+++ b/tests/I4_alu_uvm_testbench/alu_env.sv
@@ -1,7 +1,14 @@
+`include "scoreboard.sv"
+`include "coverage_collector.sv"
+`include "alu_output_monitor.sv"
+
 class alu_env extends uvm_env;
   `uvm_component_utils(alu_env)
 
-  alu_agent agent;
+  alu_agent m_agent;
+  alu_output_monitor m_output_monitor;
+  scoreboard m_scoreboard;
+  coverage_collector m_coverage;
 
   function new(string name = "alu_env", uvm_component parent = null);
     super.new(name, parent);
@@ -9,6 +16,16 @@ class alu_env extends uvm_env;
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
-    agent = alu_agent::type_id::create("agent", this);
+    m_agent = alu_agent::type_id::create("m_agent", this);
+    m_output_monitor = alu_output_monitor::type_id::create("m_output_monitor", this);
+    m_scoreboard = scoreboard::type_id::create("m_scoreboard", this);
+    m_coverage = coverage_collector::type_id::create("m_coverage", this);
+  endfunction
+
+  function void connect_phase(uvm_phase phase);
+    super.connect_phase(phase);
+    m_agent.m_monitor.item_collected_port.connect(m_scoreboard.input_analysis_export);
+    m_agent.m_monitor.item_collected_port.connect(m_coverage.analysis_export);
+    m_output_monitor.item_collected_port.connect(m_scoreboard.output_analysis_export);
   endfunction
 endclass

--- a/tests/I4_alu_uvm_testbench/alu_if.sv
+++ b/tests/I4_alu_uvm_testbench/alu_if.sv
@@ -1,20 +1,17 @@
-interface alu_if (input logic clk);
-  logic reset;
-  logic [3:0] a;
-  logic [3:0] b;
-  enum {ADD, SUB} opcode;
-  logic [4:0] y;
+interface alu_if (input bit clk);
+  logic [7:0] a;
+  logic [7:0] b;
+  logic [3:0] op;
+  logic start;
+  logic done;
+  logic [7:0] result;
 
-  // Modport for the Testbench side
-  modport Testbench (
-    output a, b, opcode, reset,
-    input  y,
-    input  clk
-  );
+  clocking driver_cb @(posedge clk);
+    output a, b, op, start;
+  endclocking
 
-  // Modport for the DUT side
-  modport DUT (
-    input  a, b, opcode, reset, clk,
-    output y
-  );
+  clocking monitor_cb @(posedge clk);
+    input a, b, op, start, done, result;
+  endclocking
+
 endinterface

--- a/tests/I4_alu_uvm_testbench/alu_monitor.sv
+++ b/tests/I4_alu_uvm_testbench/alu_monitor.sv
@@ -2,11 +2,11 @@ class alu_monitor extends uvm_monitor;
   `uvm_component_utils(alu_monitor)
 
   virtual alu_if vif;
-  uvm_analysis_port #(alu_transaction) analysis_port;
+  uvm_analysis_port #(alu_transaction) item_collected_port;
 
   function new(string name = "alu_monitor", uvm_component parent = null);
     super.new(name, parent);
-    analysis_port = new("analysis_port", this);
+    item_collected_port = new("item_collected_port", this);
   endfunction
 
   function void build_phase(uvm_phase phase);
@@ -21,8 +21,8 @@ class alu_monitor extends uvm_monitor;
       alu_transaction tx = alu_transaction::type_id::create("tx");
       tx.a = vif.a;
       tx.b = vif.b;
-      tx.opcode = vif.opcode;
-      analysis_port.write(tx);
+      tx.op = alu_op_e'(vif.op);
+      item_collected_port.write(tx);
     end
   endtask
 endclass

--- a/tests/I4_alu_uvm_testbench/alu_output_monitor.sv
+++ b/tests/I4_alu_uvm_testbench/alu_output_monitor.sv
@@ -1,0 +1,34 @@
+`ifndef ALU_OUTPUT_MONITOR_SV
+`define ALU_OUTPUT_MONITOR_SV
+
+class alu_output_monitor extends uvm_monitor;
+  `uvm_component_utils(alu_output_monitor)
+
+  virtual alu_if vif;
+  uvm_analysis_port #(alu_transaction) item_collected_port;
+
+  function new(string name = "alu_output_monitor", uvm_component parent = null);
+    super.new(name, parent);
+    item_collected_port = new("item_collected_port", this);
+  endfunction
+
+  virtual function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    if (!uvm_config_db#(virtual alu_if)::get(this, "", "vif", vif))
+      `uvm_fatal("NOVIF", "Could not get virtual interface")
+  endfunction
+
+  virtual task run_phase(uvm_phase phase);
+    forever begin
+      @(vif.monitor_cb);
+      if (vif.monitor_cb.done) begin
+        alu_transaction item = new();
+        item.result = vif.monitor_cb.result;
+        item_collected_port.write(item);
+      end
+    end
+  endtask
+
+endclass
+
+`endif // ALU_OUTPUT_MONITOR_SV

--- a/tests/I4_alu_uvm_testbench/alu_transaction.sv
+++ b/tests/I4_alu_uvm_testbench/alu_transaction.sv
@@ -1,12 +1,16 @@
+typedef enum {ADD, SUB, MUL} alu_op_e;
+
 class alu_transaction extends uvm_sequence_item;
-  rand logic [3:0] a;
-  rand logic [3:0] b;
-  rand enum {ADD, SUB} opcode;
+  rand logic [7:0] a;
+  rand logic [7:0] b;
+  rand alu_op_e op;
+  logic [7:0] result;
 
   `uvm_object_utils_begin(alu_transaction)
     `uvm_field_int(a, UVM_ALL_ON)
     `uvm_field_int(b, UVM_ALL_ON)
-    `uvm_field_enum(opcode, UVM_ALL_ON)
+    `uvm_field_enum(alu_op_e, op, UVM_ALL_ON)
+    `uvm_field_int(result, UVM_ALL_ON)
   `uvm_object_utils_end
 
   function new(string name = "alu_transaction");

--- a/tests/I4_alu_uvm_testbench/base_test.sv
+++ b/tests/I4_alu_uvm_testbench/base_test.sv
@@ -1,7 +1,7 @@
 class base_test extends uvm_test;
   `uvm_component_utils(base_test)
 
-  alu_env env;
+  alu_env m_env;
 
   function new(string name = "base_test", uvm_component parent = null);
     super.new(name, parent);
@@ -9,14 +9,14 @@ class base_test extends uvm_test;
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
-    env = alu_env::type_id::create("env", this);
+    m_env = alu_env::type_id::create("m_env", this);
   endfunction
 
   task run_phase(uvm_phase phase);
     alu_base_sequence seq;
     phase.raise_objection(this);
     seq = alu_base_sequence::type_id::create("seq");
-    seq.start(env.agent.drv.seq_item_port);
+    seq.start(m_env.m_agent.m_sequencer);
     phase.drop_objection(this);
   endtask
 endclass

--- a/tests/I4_alu_uvm_testbench/coverage_collector.sv
+++ b/tests/I4_alu_uvm_testbench/coverage_collector.sv
@@ -1,0 +1,24 @@
+`ifndef COVERAGE_COLLECTOR_SV
+`define COVERAGE_COLLECTOR_SV
+
+class coverage_collector extends uvm_subscriber #(alu_transaction);
+  `uvm_component_utils(coverage_collector)
+
+  covergroup alu_op_cg with function sample(alu_transaction trans);
+    option.per_instance = 1;
+    OP_CP: coverpoint trans.op;
+  endgroup
+
+  function new(string name = "coverage_collector", uvm_component parent = null);
+    super.new(name, parent);
+    alu_op_cg = new();
+  endfunction
+
+  function void write(alu_transaction t);
+    `uvm_info("COVERAGE", "Sampling transaction in covergroup", UVM_HIGH)
+    alu_op_cg.sample(t);
+  endfunction
+
+endclass
+
+`endif // COVERAGE_COLLECTOR_SV

--- a/tests/I4_alu_uvm_testbench/scoreboard.sv
+++ b/tests/I4_alu_uvm_testbench/scoreboard.sv
@@ -1,0 +1,65 @@
+`ifndef SCOREBOARD_SV
+`define SCOREBOARD_SV
+
+class scoreboard extends uvm_scoreboard;
+  `uvm_component_utils(scoreboard)
+
+  uvm_analysis_imp #(alu_transaction, scoreboard) input_analysis_export;
+  uvm_analysis_imp #(alu_transaction, scoreboard) output_analysis_export;
+
+  uvm_tlm_analysis_fifo #(alu_transaction) input_fifo;
+  uvm_tlm_analysis_fifo #(alu_transaction) output_fifo;
+
+  function new(string name = "scoreboard", uvm_component parent = null);
+    super.new(name, parent);
+  endfunction
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    input_analysis_export = new("input_analysis_export", this);
+    output_analysis_export = new("output_analysis_export", this);
+    input_fifo = new("input_fifo", this);
+    output_fifo = new("output_fifo", this);
+  endfunction
+
+  function void connect_phase(uvm_phase phase);
+    input_analysis_export.connect(input_fifo.analysis_export);
+    output_analysis_export.connect(output_fifo.analysis_export);
+  endfunction
+
+  task run_phase(uvm_phase phase);
+    alu_transaction input_tx, output_tx;
+    alu_transaction expected_tx;
+
+    forever begin
+      input_fifo.get(input_tx);
+      output_fifo.get(output_tx);
+
+      `uvm_info("SCOREBOARD", $sformatf("Checking transaction: op=%s, a=%0h, b=%0h",
+                input_tx.op.name(), input_tx.a, input_tx.b), UVM_HIGH)
+
+      expected_tx = new();
+      predict_result(input_tx, expected_tx);
+
+      if (!expected_tx.compare(output_tx)) begin
+        `uvm_error("SCOREBOARD_MISMATCH", $sformatf("Scoreboard check FAILED. Expected: %s, Actual: %s",
+                   expected_tx.convert2string(), output_tx.convert2string()))
+      end else begin
+        `uvm_info("SCOREBOARD_MATCH", "Scoreboard check PASSED.", UVM_HIGH)
+      end
+    end
+  endtask
+
+  function void predict_result(alu_transaction in_tx, ref alu_transaction out_tx);
+    out_tx.op = in_tx.op;
+    case (in_tx.op)
+      ADD: out_tx.result = in_tx.a + in_tx.b;
+      SUB: out_tx.result = in_tx.a - in_tx.b;
+      MUL: out_tx.result = in_tx.a * in_tx.b;
+      default: out_tx.result = 'x;
+    endcase
+  endfunction
+
+endclass
+
+`endif // SCOREBOARD_SV

--- a/tests/I4_alu_uvm_testbench/tb_top.sv
+++ b/tests/I4_alu_uvm_testbench/tb_top.sv
@@ -1,13 +1,31 @@
+`include "uvm_macros.svh"
+import uvm_pkg::*;
+
+`include "alu_if.sv"
+`include "alu_transaction.sv"
+`include "alu_driver.sv"
+`include "alu_monitor.sv"
+`include "alu_agent.sv"
+`include "alu_env.sv"
+`include "base_test.sv"
+`include "alu_base_sequence.sv"
+
 module tb_top;
   logic clk = 0;
   always #5 clk = ~clk;
 
   alu_if vif(clk);
-  alu dut(.alu_port(vif.DUT));
+  alu dut(
+    .a(vif.a),
+    .b(vif.b),
+    .op(vif.op),
+    .result(vif.result),
+    .start(vif.start),
+    .done(vif.done)
+  );
 
   initial begin
-    uvm_config_db#(virtual alu_if)::set(null, "uvm_test_top.env.agent.drv", "vif", vif);
-    uvm_config_db#(virtual alu_if)::set(null, "uvm_test_top.env.agent.mon", "vif", vif);
+    uvm_config_db#(virtual alu_if)::set(null, "*", "vif", vif);
     run_test("base_test");
   end
 endmodule


### PR DESCRIPTION
This commit introduces the module 'A2 – Scoreboards and Functional Coverage in UVM'. This module is critical for teaching you how to build self-checking testbenches and measure their effectiveness.

The new module explains how to design and implement a UVM scoreboard for automated, self-checking tests. Also, it shows how to integrate UVM's functional coverage capabilities into the environment.

Tasks completed:
- Created a new file: docs/T3_Advanced/A2_Scoreboards_and_Coverage.md.
- Updated the navigation sidebar.
- Developed content for Scoreboard Implementation.
- Developed content for UVM Functional Coverage.
- Modified the ALU testbench from I4 to include the new scoreboard and coverage components.
- Adhered to the style-guide.md.
- Updated the testbench code in tests/I4_alu_uvm_testbench/ to include the new scoreboard and coverage components, ensuring it remains runnable.
- Concluded with a case study: "How a scoreboard caught a bug where the ALU subtraction was off-by-one."