### PR TITLE
feat: Create New Module A3 – UVM Configurations and Factory Mastery

### DIFF
--- a/docs/T3_Advanced/A3_Config_and_Factory_Mastery.md
+++ b/docs/T3_Advanced/A3_Config_and_Factory_Mastery.md
@@ -1,0 +1,193 @@
+---
+sidebar_label: 'A3 - Config and Factory Mastery'
+sidebar_position: 3
+---
+
+# A3 – UVM Configurations and Factory Mastery
+
+You've learned the basics of the UVM factory and configuration database (`uvm_config_db`). Now it's time to master them. These two components are the heart of UVM's power, enabling the creation of highly reusable, modular, and customizable testbench environments.
+
+## 1. Advanced Factory Usage: Polymorphism in Action
+
+The factory's primary purpose is to enable **polymorphism**—the ability to substitute one type of component or object for another at runtime without changing the testbench's source code. This is the key to creating flexible and reusable verification IP.
+
+### Example: The Error-Injecting Driver
+
+Imagine you have a standard, well-behaved `alu_driver`. Now, you want to create a special test that injects errors. Instead of creating a whole new environment, you can create a specialized `error_injecting_driver` and use the factory to swap it in.
+
+1.  **Base Driver (`alu_driver.sv`)**: This is the standard driver.
+
+    ```systemverilog
+    class alu_driver extends uvm_driver #(alu_transaction);
+      `uvm_component_utils(alu_driver)
+      // ... standard driver logic ...
+    endclass
+    ```
+
+2.  **Extended Driver (`error_injecting_driver.sv`)**: This driver extends the base driver and overrides the `run_phase` to sometimes corrupt the data.
+
+    ```systemverilog
+    class error_injecting_driver extends alu_driver;
+      `uvm_component_utils(error_injecting_driver)
+
+      virtual task run_phase(uvm_phase phase);
+        // ... gets item from sequencer ...
+        if ($urandom_range(0, 9) == 0) begin // 10% chance to inject error
+          `uvm_info("INJECT_ERROR", "Corrupting opcode!", UVM_MEDIUM)
+          req.op = alu_op_e'($urandom); // Corrupt the opcode
+        end
+        // ... drives the (possibly corrupted) transaction ...
+      endtask
+    endclass
+    ```
+
+3.  **The Tests**: The environment code is identical for both tests. The only difference is the factory override in the `error_test`.
+
+    -   **`base_test.sv`**: Uses the default driver. No overrides needed.
+
+        ```systemverilog
+        class base_test extends uvm_test;
+          // ... build_phase instantiates the environment ...
+        endclass
+        ```
+
+    -   **`error_test.sv`**: Uses the factory to replace `alu_driver` with `error_injecting_driver`.
+
+        ```systemverilog
+        class error_test extends base_test;
+          `uvm_component_utils(error_test)
+
+          function void build_phase(uvm_phase phase);
+            super.build_phase(phase);
+            // Override the driver for the agent inside our environment
+            alu_driver::type_id::set_inst_override(error_injecting_driver::get_type(),
+                                                   "m_env.m_agent.*");
+          endfunction
+        endclass
+        ```
+
+When `error_test` runs, any time the environment tries to create an `alu_driver` (i.e., `alu_driver::type_id::create()`), the factory will return an instance of `error_injecting_driver` instead.
+
+### Factory Debugging
+
+How do you know which overrides are active? The factory provides a built-in debugging tool.
+
+```systemverilog
+// In your test's end_of_elaboration_phase
+function void end_of_elaboration_phase(uvm_phase phase);
+  super.end_of_elaboration_phase(phase);
+  factory.print(); // Print all factory overrides
+endfunction
+```
+
+This will print a table showing all the instance and type overrides currently registered with the factory, which is invaluable for debugging complex test scenarios.
+
+### The `uvm_object_wrapper`
+
+You'll notice that the factory override methods (`set_inst_override`, `set_type_override`) don't take strings as arguments for the types; they take `uvm_object_wrapper`s. The `::get_type()` static method returns this wrapper.
+
+The `uvm_component_utils` and `uvm_object_utils` macros create these static `get_type()` functions for you. The wrapper is a lightweight object that represents the class type, allowing the factory to work with types as objects.
+
+## 2. Advanced `uvm_config_db` Usage
+
+While the factory changes the *type* of a component, the `uvm_config_db` changes its *behavior and structure*.
+
+### Configuration Objects
+
+Passing individual settings (like `int`, `string`, `virtual interface`) is fine for simple cases. However, for a complex component like an agent, it's much cleaner and more scalable to group all its settings into a single **configuration object**.
+
+1.  **Create a Config Class (`alu_agent_config.sv`)**: This class extends `uvm_object` (not `uvm_component`) and holds all the agent's configuration knobs.
+
+    ```systemverilog
+    class alu_agent_config extends uvm_object;
+      `uvm_object_utils(alu_agent_config)
+
+      // Is the agent active (driver+sequencer) or passive (monitor only)?
+      uvm_active_passive_enum is_active = UVM_ACTIVE;
+
+      // Should the coverage collector be created?
+      bit has_coverage = 1;
+
+      // Handle to the virtual interface
+      virtual alu_if vif;
+
+      function new(string name = "alu_agent_config");
+        super.new(name);
+      endfunction
+    endclass
+    ```
+
+2.  **Set the Object in the Test**: The test is responsible for creating and setting the configuration object.
+
+    ```systemverilog
+    // In the test's build_phase
+    m_agent_config = alu_agent_config::type_id::create("m_agent_config");
+    m_agent_config.is_active = UVM_PASSIVE; // Configure for this specific test
+    m_agent_config.has_coverage = 0;
+    uvm_config_db#(alu_agent_config)::set(this, "m_env.m_agent", "config", m_agent_config);
+    ```
+
+3.  **Get the Object in the Component**: The agent retrieves the single configuration object and uses it to build itself.
+
+    ```systemverilog
+    // In the agent's build_phase
+    alu_agent_config m_config;
+
+    virtual function void build_phase(uvm_phase phase);
+      super.build_phase(phase);
+      if (!uvm_config_db#(alu_agent_config)::get(this, "", "config", m_config))
+        `uvm_fatal("NO_CONFIG", "Agent config not found!")
+
+      // Now use the config object to conditionally build components
+      if (m_config.is_active == UVM_ACTIVE) begin
+        m_driver = alu_driver::type_id::create("m_driver", this);
+        m_sequencer = uvm_sequencer...::type_id::create("m_sequencer", this);
+      end
+      m_monitor = alu_monitor::type_id::create("m_monitor", this);
+
+      if (m_config.has_coverage) begin
+        // create coverage component...
+      end
+    endfunction
+    ```
+
+This pattern makes the agent highly reusable. The same agent component can be configured to be active, passive, or have different features enabled or disabled, just by changing the configuration object passed from the test.
+
+### The Resource Database (`uvm_resource_db`)
+
+The `uvm_config_db` is actually a convenience wrapper around a more fundamental class: `uvm_resource_db`. The resource database is a more general-purpose database for sharing information across the testbench. Resources have properties like precedence, which can be used to resolve conflicts if multiple components try to set the same resource.
+
+For 99% of verification work, `uvm_config_db` is the right tool. You only need to drop down to `uvm_resource_db` for very advanced use cases, such as building custom configuration mechanisms.
+
+### Scoping and Wildcards
+
+The `uvm_config_db::set` call takes an instance path as its second argument. This path can include wildcards (`*` or `?`) to set a configuration for multiple components at once.
+
+```systemverilog
+// Set the "recording_detail" for ALL components in the testbench
+uvm_config_db#(int)::set(this, "*", "recording_detail", UVM_FULL);
+
+// Set the virtual interface for the driver and monitor in m_agent_a
+uvm_config_db#(virtual alu_if)::set(this, "m_env.m_agent_a.*", "vif", m_vif);
+```
+
+## 3. Practical Example: Active/Passive Agent
+
+This example demonstrates the power of a configuration object to change an agent from `UVM_ACTIVE` to `UVM_PASSIVE`.
+
+-   `base_test`: Configures the agent to be `UVM_ACTIVE`. The agent will build its driver and sequencer.
+-   `passive_test`: Configures the agent to be `UVM_PASSIVE`. The agent will only build its monitor.
+
+The environment code is identical in both cases. The testbench structure adapts dynamically based on the configuration it receives.
+
+**(The full code for this example is in `tests/A3_advanced_config_example/`)**
+
+## 4. Summary: Factory vs. Config DB
+
+Use...
+
+-   **The Factory (`set_*_override`)** when you want to **change the type** of a component or object. You are swapping one class for another compatible class (one that shares the same base class).
+    -   *Example: Replacing a standard driver with an error-injecting driver.*
+
+-   **The Configuration Database (`uvm_config_db`)** when you want to **change the behavior, structure, or settings** of a component. You are parameterizing the component.
+    -   *Example: Setting an agent to be active or passive, enabling/disabling coverage, passing a virtual interface handle.*

--- a/src/lib/curriculum-data.ts
+++ b/src/lib/curriculum-data.ts
@@ -210,6 +210,13 @@ export const curriculumData: Module[] = [
             topics: [
                 { title: "Scoreboards and Functional Coverage in UVM", slug: "index", description: "Explain how to design and implement a UVM scoreboard for automated, self-checking tests." },
             ]
+          },
+          {
+            title: "UVM Configurations and Factory Mastery",
+            slug: "A3_Config_and_Factory_Mastery",
+            topics: [
+                { title: "UVM Configurations and Factory Mastery", slug: "index", description: "Go beyond the basics of the factory and configuration database to show how they enable highly reusable, polymorphic, and customizable testbenches." },
+            ]
           }
       ]
   },

--- a/tests/A3_advanced_config_example/alu_agent.sv
+++ b/tests/A3_advanced_config_example/alu_agent.sv
@@ -1,0 +1,42 @@
+`ifndef ALU_AGENT_SV
+`define ALU_AGENT_SV
+
+`include "alu_agent_config.sv"
+
+class alu_agent extends uvm_agent;
+  `uvm_component_utils(alu_agent)
+
+  alu_driver m_driver;
+  alu_monitor m_monitor;
+  uvm_sequencer #(alu_transaction) m_sequencer;
+  alu_agent_config m_config;
+
+  function new(string name = "alu_agent", uvm_component parent = null);
+    super.new(name, parent);
+  endfunction
+
+  virtual function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    if (!uvm_config_db#(alu_agent_config)::get(this, "", "config", m_config))
+      `uvm_fatal("NO_CONFIG", "Agent config not found!")
+
+    uvm_config_db#(virtual alu_if)::set(this, "*", "vif", m_config.vif);
+
+    m_monitor = alu_monitor::type_id::create("m_monitor", this);
+
+    if (m_config.is_active == UVM_ACTIVE) begin
+      m_driver = alu_driver::type_id::create("m_driver", this);
+      m_sequencer = uvm_sequencer #(alu_transaction)::type_id::create("m_sequencer", this);
+    end
+  endfunction
+
+  virtual function void connect_phase(uvm_phase phase);
+    super.connect_phase(phase);
+    if (m_config.is_active == UVM_ACTIVE) begin
+      m_driver.seq_item_port.connect(m_sequencer.seq_item_export);
+    end
+  endfunction
+
+endclass
+
+`endif // ALU_AGENT_SV

--- a/tests/A3_advanced_config_example/alu_agent_config.sv
+++ b/tests/A3_advanced_config_example/alu_agent_config.sv
@@ -1,0 +1,16 @@
+`ifndef ALU_AGENT_CONFIG_SV
+`define ALU_AGENT_CONFIG_SV
+
+class alu_agent_config extends uvm_object;
+  `uvm_object_utils(alu_agent_config)
+
+  uvm_active_passive_enum is_active = UVM_ACTIVE;
+  bit has_coverage = 1;
+  virtual alu_if vif;
+
+  function new(string name = "alu_agent_config");
+    super.new(name);
+  endfunction
+endclass
+
+`endif // ALU_AGENT_CONFIG_SV

--- a/tests/A3_advanced_config_example/alu_driver.sv
+++ b/tests/A3_advanced_config_example/alu_driver.sv
@@ -1,0 +1,38 @@
+`ifndef ALU_DRIVER_SV
+`define ALU_DRIVER_SV
+
+class alu_driver extends uvm_driver #(alu_transaction);
+  `uvm_component_utils(alu_driver)
+
+  virtual alu_if vif;
+
+  function new(string name = "alu_driver", uvm_component parent = null);
+    super.new(name, parent);
+  endfunction
+
+  virtual function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    if (!uvm_config_db#(virtual alu_if)::get(this, "", "vif", vif))
+      `uvm_fatal("NOVIF", "Could not get virtual interface")
+  endfunction
+
+  virtual task run_phase(uvm_phase phase);
+    forever begin
+      seq_item_port.get_next_item(req);
+      drive_item(req);
+      seq_item_port.item_done();
+    end
+  endtask
+
+  virtual task drive_item(alu_transaction tx);
+      vif.driver_cb.start <= 1;
+      vif.driver_cb.a <= tx.a;
+      vif.driver_cb.b <= tx.b;
+      vif.driver_cb.op <= tx.op;
+      @(vif.driver_cb);
+      vif.driver_cb.start <= 0;
+  endtask
+
+endclass
+
+`endif // ALU_DRIVER_SV

--- a/tests/A3_advanced_config_example/alu_env.sv
+++ b/tests/A3_advanced_config_example/alu_env.sv
@@ -1,0 +1,20 @@
+`ifndef ALU_ENV_SV
+`define ALU_ENV_SV
+
+class alu_env extends uvm_env;
+  `uvm_component_utils(alu_env)
+
+  alu_agent m_agent;
+
+  function new(string name = "alu_env", uvm_component parent = null);
+    super.new(name, parent);
+  endfunction
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    m_agent = alu_agent::type_id::create("m_agent", this);
+  endfunction
+
+endclass
+
+`endif // ALU_ENV_SV

--- a/tests/A3_advanced_config_example/alu_if.sv
+++ b/tests/A3_advanced_config_example/alu_if.sv
@@ -1,0 +1,22 @@
+`ifndef ALU_IF_SV
+`define ALU_IF_SV
+
+interface alu_if (input bit clk);
+  logic [7:0] a;
+  logic [7:0] b;
+  logic [3:0] op;
+  logic start;
+  logic done;
+  logic [7:0] result;
+
+  clocking driver_cb @(posedge clk);
+    output a, b, op, start;
+  endclocking
+
+  clocking monitor_cb @(posedge clk);
+    input a, b, op, start, done, result;
+  endclocking
+
+endinterface
+
+`endif // ALU_IF_SV

--- a/tests/A3_advanced_config_example/alu_monitor.sv
+++ b/tests/A3_advanced_config_example/alu_monitor.sv
@@ -1,0 +1,36 @@
+`ifndef ALU_MONITOR_SV
+`define ALU_MONITOR_SV
+
+class alu_monitor extends uvm_monitor;
+  `uvm_component_utils(alu_monitor)
+
+  virtual alu_if vif;
+  uvm_analysis_port #(alu_transaction) item_collected_port;
+
+  function new(string name = "alu_monitor", uvm_component parent = null);
+    super.new(name, parent);
+    item_collected_port = new("item_collected_port", this);
+  endfunction
+
+  virtual function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    if (!uvm_config_db#(virtual alu_if)::get(this, "", "vif", vif))
+      `uvm_fatal("NOVIF", "Could not get virtual interface")
+  endfunction
+
+  virtual task run_phase(uvm_phase phase);
+    forever begin
+      @(vif.monitor_cb);
+      if (vif.monitor_cb.start) begin
+        alu_transaction item = new();
+        item.a = vif.monitor_cb.a;
+        item.b = vif.monitor_cb.b;
+        item.op = alu_op_e'(vif.monitor_cb.op);
+        item_collected_port.write(item);
+      end
+    end
+  endtask
+
+endclass
+
+`endif // ALU_MONITOR_SV

--- a/tests/A3_advanced_config_example/alu_transaction.sv
+++ b/tests/A3_advanced_config_example/alu_transaction.sv
@@ -1,0 +1,24 @@
+`ifndef ALU_TRANSACTION_SV
+`define ALU_TRANSACTION_SV
+
+typedef enum {ADD, SUB, MUL} alu_op_e;
+
+class alu_transaction extends uvm_sequence_item;
+  rand logic [7:0] a;
+  rand logic [7:0] b;
+  rand alu_op_e op;
+  logic [7:0] result;
+
+  `uvm_object_utils_begin(alu_transaction)
+    `uvm_field_int(a, UVM_ALL_ON)
+    `uvm_field_int(b, UVM_ALL_ON)
+    `uvm_field_enum(alu_op_e, op, UVM_ALL_ON)
+    `uvm_field_int(result, UVM_ALL_ON)
+  `uvm_object_utils_end
+
+  function new(string name = "alu_transaction");
+    super.new(name);
+  endfunction
+endclass
+
+`endif // ALU_TRANSACTION_SV

--- a/tests/A3_advanced_config_example/base_test.sv
+++ b/tests/A3_advanced_config_example/base_test.sv
@@ -1,0 +1,62 @@
+`ifndef BASE_TEST_SV
+`define BASE_TEST_SV
+
+class base_test extends uvm_test;
+  `uvm_component_utils(base_test)
+
+  alu_env m_env;
+  alu_agent_config m_agent_config;
+
+  function new(string name = "base_test", uvm_component parent = null);
+    super.new(name, parent);
+  endfunction
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+
+    m_agent_config = alu_agent_config::type_id::create("m_agent_config");
+
+    if (!uvm_config_db#(virtual alu_if)::get(this, "", "vif", m_agent_config.vif))
+      `uvm_fatal("NOVIF", "Could not get virtual interface")
+
+    uvm_config_db#(alu_agent_config)::set(this, "m_env.m_agent", "config", m_agent_config);
+
+    m_env = alu_env::type_id::create("m_env", this);
+  endfunction
+
+  function void end_of_elaboration_phase(uvm_phase phase);
+    super.end_of_elaboration_phase(phase);
+    uvm_factory::get().print();
+  endfunction
+
+endclass
+
+class error_test extends base_test;
+  `uvm_component_utils(error_test)
+
+  function new(string name = "error_test", uvm_component parent = null);
+    super.new(name, parent);
+  endfunction
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    alu_driver::type_id::set_inst_override(error_injecting_driver::get_type(),
+                                           "m_env.m_agent.m_driver");
+  endfunction
+endclass
+
+class passive_test extends base_test;
+  `uvm_component_utils(passive_test)
+
+  function new(string name = "passive_test", uvm_component parent = null);
+    super.new(name, parent);
+  endfunction
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    m_agent_config.is_active = UVM_PASSIVE;
+  endfunction
+endclass
+
+
+`endif // BASE_TEST_SV

--- a/tests/A3_advanced_config_example/error_injecting_driver.sv
+++ b/tests/A3_advanced_config_example/error_injecting_driver.sv
@@ -1,0 +1,21 @@
+`ifndef ERROR_INJECTING_DRIVER_SV
+`define ERROR_INJECTING_DRIVER_SV
+
+class error_injecting_driver extends alu_driver;
+  `uvm_component_utils(error_injecting_driver)
+
+  function new(string name = "error_injecting_driver", uvm_component parent = null);
+    super.new(name, parent);
+  endfunction
+
+  virtual task drive_item(alu_transaction tx);
+    if ($urandom_range(0, 9) == 0) begin // 10% chance to inject error
+      `uvm_info("INJECT_ERROR", "Corrupting opcode!", UVM_MEDIUM)
+      tx.op = alu_op_e'($urandom); // Corrupt the opcode
+    end
+    super.drive_item(tx);
+  endtask
+
+endclass
+
+`endif // ERROR_INJECTING_DRIVER_SV

--- a/tests/A3_advanced_config_example/tb_top.sv
+++ b/tests/A3_advanced_config_example/tb_top.sv
@@ -1,0 +1,24 @@
+`include "uvm_macros.svh"
+import uvm_pkg::*;
+
+`include "alu_if.sv"
+`include "alu_transaction.sv"
+`include "alu_driver.sv"
+`include "error_injecting_driver.sv"
+`include "alu_monitor.sv"
+`include "alu_agent.sv"
+`include "alu_env.sv"
+`include "base_test.sv"
+
+module tb_top;
+  bit clk;
+  always #5 clk = ~clk;
+
+  alu_if vif(clk);
+
+  initial begin
+    uvm_config_db#(virtual alu_if)::set(null, "*", "vif", vif);
+    run_test("base_test");
+  end
+
+endmodule


### PR DESCRIPTION
This commit introduces the module 'A3 – UVM Configurations and Factory Mastery'. This module will explore advanced, powerful uses of UVM's core mechanisms.

The new module goes beyond the basics of the factory and configuration database to show how they enable highly reusable, polymorphic, and customizable testbenches.

Tasks completed:
- Created a new file: docs/T3_Advanced/A3_Config_and_Factory_Mastery.md.
- Updated the navigation sidebar.
- Developed content for Advanced Factory Usage.
- Developed content for Advanced uvm_config_db Usage.
- Created a practical example with a configuration object and active/passive tests.
- Adhered to the style-guide.md.
- Created a new directory tests/A3_advanced_config_example/ containing the complete, runnable code for the configuration object and active/passive test example.
- Concluded with a summary of when to use factory overrides vs. configuration.