### PR TITLE
feat: Create New Module A5 – Scaling Testbenches and UVM Tips

### DIFF
--- a/docs/T3_Advanced/A5_Scaling_Testbenches.md
+++ b/docs/T3_Advanced/A5_Scaling_Testbenches.md
@@ -1,0 +1,158 @@
+---
+sidebar_label: 'A5 - Scaling Testbenches and UVM Tips'
+sidebar_position: 5
+---
+
+# A5 – Scaling Testbenches and UVM Tips
+
+Writing a UVM testbench for a simple block is one thing; managing a verification project for a complex SoC with hundreds or thousands of tests is another. As projects grow, new challenges arise related to organization, automation, and debugging. This module provides practical advice and best practices for scaling your UVM environments and avoiding common pitfalls.
+
+## 1. Managing Many Tests
+
+A mature verification project will have a large and diverse set of tests. Managing them effectively is key to an efficient regression process.
+
+### Test Suites
+
+Don't lump all your tests into one bucket. Group them into logical **suites** based on their purpose. This allows you to run different sets of tests at different stages of the project.
+
+-   **Smoke Tests**: A small, quick-running set of tests that verify the most basic functionality. These are often run by designers before they even check in new RTL code.
+-   **Regression Tests**: The main body of tests that cover the majority of the DUT's functionality. This suite is typically run nightly.
+-   **Error Tests**: Tests that specifically target error conditions and illegal stimulus.
+-   **Performance Tests**: Tests that focus on stressing the DUT's performance, often with high-bandwidth traffic.
+-   **Coverage Tests**: Tests written specifically to hit difficult functional coverage points.
+
+### Build Automation
+
+You cannot manually run hundreds of tests. The regression process must be automated. This is typically done with scripts written in Python, Perl, or using a tool like `make`.
+
+A regression script's job is to:
+
+1.  Read a list of test names for a given suite.
+2.  For each test, compile the RTL and testbench.
+3.  Run the simulation, passing the test name as a plusarg (`+UVM_TESTNAME=my_test_name`).
+4.  Check the simulation log for a "UVM_FATAL" or "UVM_ERROR" to determine if the test passed or failed.
+5.  Collect all results into a coherent report.
+
+**Pseudo-code for a simple regression script:**
+
+```python
+# simple_regression.py
+test_suite = ["test_basic_add", "test_all_ops", "test_max_values"]
+for test_name in test_suite:
+  print(f"Running test: {test_name}")
+  # Compile step
+  compile_cmd = f"vcs -sverilog ... +define+UVM_TESTNAME={test_name} ..."
+  run_command(compile_cmd)
+  # Simulation step
+  sim_cmd = "./simv"
+  log_file = f"{test_name}.log"
+  run_command(sim_cmd, stdout=log_file)
+  # Check for errors
+  if "UVM_ERROR" in read_file(log_file):
+    print(f"  --> {test_name}: FAILED")
+  else:
+    print(f"  --> {test_name}: PASSED")
+```
+
+### Test Promotion
+
+New tests don't go directly into the main regression. They follow a promotion process:
+
+1.  **Development**: An engineer writes a new test locally.
+2.  **Debugging**: The engineer runs and debugs the test until it passes reliably on their machine.
+3.  **Code Review**: The test code is reviewed by peers for correctness and style.
+4.  **Promotion**: Once approved, the test is added to the official regression suite.
+
+### Test Seeding
+
+A single test using constrained-random stimulus only explores one random path through the state space. To truly leverage randomization, you must run the same test with many different **random seeds**. A different seed will cause all the `randomize()` calls to produce a different set of values, exercising different corner cases.
+
+You can control the seed from the command line with a simulator-specific plusarg.
+
+```bash
+# Run the same test with three different seeds
+./simv +UVM_TESTNAME=test_random_ops +ntb_random_seed=1
+./simv +UVM_TESTNAME=test_random_ops +ntb_random_seed=2
+./simv +UVM_TESTNAME=test_random_ops +ntb_random_seed=3
+```
+
+Your regression script should be able to manage running tests with multiple seeds.
+
+## 2. Organizing a Large Testbench
+
+A clean, standardized structure is essential for a large project that multiple engineers will work on.
+
+### File and Directory Structure
+
+Adopt a standard directory structure for all your verification components. This makes it easy for anyone on the team to find files.
+
+```
+/my_project
+|-- /sim                # Simulation scripts, Makefiles
+|-- /tests              # All test class files
+|-- /sequences          # All sequence class files
+|-- /env                # Top-level environment components
+|-- /agents
+|   |-- /alu_agent      # Agent-specific files
+|   |-- /axi_agent
+|-- /interfaces         # SystemVerilog interfaces
+|-- /docs               # Documentation
+```
+
+### The Importance of Base Classes
+
+Just as `uvm_test` is the base for all tests, you should create your own project-specific base classes for all major component types.
+
+-   **`project_base_test`**: All your tests should extend this class, not `uvm_test` directly. This base test can contain common configuration, handles to the top-level environment, and other setup logic that is shared by all tests in the project.
+-   **`project_base_sequence`**: Can contain common utility tasks or properties that all sequences in the project might need.
+-   **`project_base_driver`**, **`project_base_monitor`**, etc.
+
+This practice makes your testbench much easier to maintain. If you need to add a new configuration setting to all tests, you only need to add it in one place: `project_base_test`.
+
+### SystemVerilog Packages
+
+As your testbench grows, you'll have dozens or hundreds of class definitions. If these are all compiled into the global namespace, you risk name collisions. **SystemVerilog packages** are the solution. A package is a local namespace for a set of definitions.
+
+1.  **Define the Package**: Group related classes into a package file.
+
+    ```systemverilog
+    // alu_agent_pkg.sv
+    package alu_agent_pkg;
+      `include "uvm_macros.svh"
+      import uvm_pkg::*;
+
+      `include "alu_transaction.sv"
+      `include "alu_driver.sv"
+      `include "alu_monitor.sv"
+      // ... etc.
+    endpackage
+    ```
+
+2.  **Compile and Import**: Compile the package first, and then import it where needed.
+
+    ```systemverilog
+    // top.sv
+    import alu_agent_pkg::*; // Import all names from the package
+
+    module top;
+      // ...
+    endmodule
+    ```
+
+Using packages is a critical best practice for any non-trivial UVM environment.
+
+## 3. Common UVM Pitfalls and Tips
+
+Here are some of the most common problems encountered in large UVM projects and how to solve them.
+
+| Pitfall | Problem Description | Solution / Tip |
+| :--- | :--- | :--- |
+| **`uvm_config_db` Typos** | You use `uvm_config_db::set(this, "m_env.m_agent", "vif", m_vif)` but the agent does a `get()` with the field name `"viff"`. The `get()` will fail, but this can be hard to debug. | Create a `project_constants_pkg` that contains `const string` definitions for all your config DB field names. This turns string typos into compile-time errors. |
+| **Factory Override Bugs** | You try to override a component with an incompatible type, or you forget to include the `uvm_component_utils` macro in a new class, so the factory doesn't know about it. | Use `factory.print()` in your base test's `end_of_elaboration_phase` to see exactly which overrides are active. This is your number one factory debugging tool. |
+| **Objection Hung** | A test runs forever and never ends. This almost always means a component raised a phase objection (`phase.raise_objection(this)`) but never dropped it. | Run your simulation with the `+UVM_OBJECTION_TRACE` plusarg. This will print a message every time an objection is raised or dropped, showing you the component responsible. The last one to raise an objection without a corresponding drop is the culprit. |
+| **TLM Port Connections** | You create a monitor with an `uvm_analysis_port` but forget to `connect()` it in the environment. The simulation runs, but no data ever reaches your scoreboard. | UVM will often (but not always) print a warning about unbound TLM ports at the end of elaboration. Pay close attention to these warnings. There is no substitute for carefully reviewing your `connect_phase` code. |
+| **Simulation Performance** | Your regression suite is taking too long to run. | Extensive use of `` `uvm_info `` with `UVM_MEDIUM` or `UVM_LOW` verbosity can significantly slow down simulations. For messages inside tight loops (e.g., in a driver), use `UVM_HIGH` or `UVM_DEBUG` so they are off by default. Use profiling tools from your simulator vendor to identify bottlenecks. |
+
+---
+
+**Conclusion**: Scaling a UVM testbench requires more than just knowing the UVM library. It requires a **methodology**. By establishing clear file structures, using base classes and packages, automating your regressions, and being aware of common pitfalls, you can build a verification environment that is robust, maintainable, and efficient for the entire project team.

--- a/src/lib/curriculum-data.ts
+++ b/src/lib/curriculum-data.ts
@@ -224,6 +224,13 @@ export const curriculumData: Module[] = [
             topics: [
                 { title: "UVM Verification IP Integration", slug: "index", description: "Provide practical guidelines and a conceptual framework for integrating pre-written or third-party Verification IP (VIP) into a custom UVM environment." },
             ]
+          },
+          {
+            title: "Scaling Testbenches and UVM Tips",
+            slug: "A5_Scaling_Testbenches",
+            topics: [
+                { title: "Scaling Testbenches and UVM Tips", slug: "index", description: "Discuss techniques for managing hundreds of tests, organizing large testbenches, and avoiding common UVM pitfalls that appear at scale." },
+            ]
           }
       ]
   },


### PR DESCRIPTION
This commit introduces the module 'A5 – Scaling Testbenches and UVM Tips'. This module provides advice for managing large, real-world verification projects.

The new module discusses techniques for managing hundreds of tests, organizing large testbenches, and avoiding common UVM pitfalls that appear at scale.

I have completed the following:
- Created a new file: docs/T3_Advanced/A5_Scaling_Testbenches.md.
- Updated the navigation sidebar.
- Developed content for Managing Many Tests.
- Developed content for Organizing a Large Testbench.
- Developed content for Common UVM Pitfalls and Tips.
- Adhered to the style-guide.md.
- Concluded the module with a summary.