### PR TITLE
feat: Scaffold new Interactive UVM Testbench page

### DIFF
--- a/content/curriculum/interactive-tools/uvm-visualizers/interactive-testbench/index.mdx
+++ b/content/curriculum/interactive-tools/uvm-visualizers/interactive-testbench/index.mdx
@@ -1,17 +1,9 @@
 ---
-title: "Interactive UVM Testbench Visualizer"
-description: "An interactive tool to explore and understand the components of a UVM testbench."
+title: Interactive UVM Testbench
+description: A hands-on, interactive visualizer for exploring the UVM testbench architecture, phasing, and data flow in real-time.
 ---
+import { UvmTestbenchVisualizer } from '@/components/diagrams/UvmTestbenchVisualizer';
 
-import { Panel } from '@/components/ui';
-import UvmTestbenchVisualizer from '@/components/diagrams/UvmTestbenchVisualizer';
+# Interactive UVM Testbench
 
-## Welcome to the Interactive UVM Testbench Visualizer
-
-This is a new interactive page designed to help you visualize the structure and relationships within a standard UVM testbench. Explore the different components and see how they connect to one another.
-
-<Panel>
-  <UvmTestbenchVisualizer />
-</Panel>
-
-This tool is currently under construction, but will be expanded with more features to provide a rich learning experience.
+<UvmTestbenchVisualizer />

--- a/src/components/diagrams/UvmTestbenchVisualizer.tsx
+++ b/src/components/diagrams/UvmTestbenchVisualizer.tsx
@@ -1,41 +1,13 @@
-"use client";
+'use client';
+
 import React from 'react';
-import { motion } from 'framer-motion';
 
 const UvmTestbenchVisualizer = () => {
   return (
-    <svg className="w-full h-auto" viewBox="0 0 800 600" style={{ border: '1px solid hsl(var(--border))', borderRadius: '8px' }} role="img" aria-label="Interactive UVM Testbench Visualizer">
-      <style>
-        {`
-          .background { fill: hsl(var(--background)); }
-          .title { font-size: 24px; font-weight: bold; fill: hsl(var(--foreground)); text-anchor: middle; }
-          .subtitle { font-size: 16px; fill: hsl(var(--muted-foreground)); text-anchor: middle; }
-        `}
-      </style>
-
-      {/* Background */}
-      <rect width="100%" height="100%" className="background" />
-
-      {/* Placeholder Text */}
-      <text x="400" y="280" className="title">
-        Interactive UVM Testbench Visualizer
+    <svg width="100%" height="500px" style={{ border: '1px solid #ccc' }}>
+      <text x="50%" y="50%" dominantBaseline="middle" textAnchor="middle" fontSize="20" fill="#888">
+        UVM Visualizer Placeholder
       </text>
-      <text x="400" y="310" className="subtitle">
-        (Component Under Construction)
-      </text>
-
-      {/* Example Interactive Element */}
-      <motion.g
-        whileHover={{ scale: 1.1 }}
-        whileTap={{ scale: 0.9 }}
-        drag
-        dragConstraints={{ left: 0, right: 700, top: 0, bottom: 500 }}
-      >
-        <rect x="350" y="400" width="100" height="50" rx="5" fill="hsl(var(--primary))" />
-        <text x="400" y="430" textAnchor="middle" fill="hsl(var(--primary-foreground))">
-          Drag Me
-        </text>
-      </motion.g>
     </svg>
   );
 };

--- a/src/lib/curriculum-data.ts
+++ b/src/lib/curriculum-data.ts
@@ -221,9 +221,9 @@ export const curriculumData: Module[] = [
         slug: "uvm-visualizers",
         topics: [
           {
-            title: "Interactive Testbench Visualizer",
+            title: "Interactive UVM Testbench",
             slug: "interactive-testbench",
-            description: "An interactive tool to explore and understand the components of a UVM testbench."
+            description: "A hands-on, interactive visualizer for exploring the UVM testbench architecture, phasing, and data flow in real-time."
           }
         ]
       }


### PR DESCRIPTION
This commit scaffolds the new "Interactive UVM Testbench" page based on the detailed project requirements. It overwrites the previous implementation with the specified content.

The changes include:
- The `UvmTestbenchVisualizer.tsx` component has been updated with a new placeholder SVG as specified.
- The MDX page at `content/curriculum/interactive-tools/uvm-visualizers/interactive-testbench/index.mdx` has been updated with the new title, description, and component embedding.
- The navigation data in `src/lib/curriculum-data.ts` has been updated to align the topic's title and description with the new page's front-matter for consistency.

This completes the scaffolding of the new feature as you requested.