### PR TITLE
feat: Implement static D3.js visualization of UVM testbench

### DIFF
--- a/src/components/diagrams/UvmTestbenchVisualizer.tsx
+++ b/src/components/diagrams/UvmTestbenchVisualizer.tsx
@@ -1,25 +1,79 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import * as d3 from 'd3';
-import { gsap } from 'gsap';
 import { uvmComponents, uvmConnections } from './uvm-data-model';
+import { UvmComponent } from './uvm-data-model';
 
 const UvmTestbenchVisualizer = () => {
+  const svgRef = useRef<SVGSVGElement>(null);
+
   useEffect(() => {
-    console.log('D3 version:', d3.version);
-    console.log('GSAP object:', gsap);
-    console.log('UVM Components:', uvmComponents);
-    console.log('UVM Connections:', uvmConnections);
+    if (!svgRef.current) return;
+
+    const width = svgRef.current.clientWidth;
+    const height = svgRef.current.clientHeight;
+
+    const svg = d3.select(svgRef.current);
+    // Clear previous renders
+    svg.selectAll('*').remove();
+
+    // 1. Set up a force simulation
+    const simulation = d3.forceSimulation(uvmComponents as d3.SimulationNodeDatum[])
+      .force('link', d3.forceLink(uvmConnections).id(d => (d as UvmComponent).id).distance(100))
+      .force('charge', d3.forceManyBody().strength(-300))
+      .force('center', d3.forceCenter(width / 2, height / 2));
+
+    // 2. Create links (lines)
+    const link = svg.append('g')
+      .attr('stroke-opacity', 0.6)
+      .selectAll('line')
+      .data(uvmConnections)
+      .join('line')
+      .attr('stroke', d => {
+        if (d.type === 'analysis') return '#2ecc71';
+        if (d.type === 'seq_item') return '#3498db';
+        return '#999';
+      })
+      .attr('stroke-width', d => d.type === 'seq_item' ? 2.5 : 1.5)
+      .attr('stroke-dasharray', d => d.type === 'analysis' ? '5,5' : 'none');
+
+    // 3. Create nodes (groups of rect + text)
+    const node = svg.append('g')
+      .selectAll('g')
+      .data(uvmComponents)
+      .join('g');
+
+    node.append('rect')
+      .attr('width', 140)
+      .attr('height', 40)
+      .attr('rx', 5)
+      .attr('ry', 5)
+      .attr('fill', '#f0f0f0')
+      .attr('stroke', '#333');
+
+    node.append('text')
+      .text(d => d.name)
+      .attr('x', 70)
+      .attr('y', 20)
+      .attr('text-anchor', 'middle')
+      .attr('dominant-baseline', 'middle')
+      .attr('fill', '#000');
+
+    // 4. Update positions on each 'tick' of the simulation
+    simulation.on('tick', () => {
+      link
+        .attr('x1', d => (d.source as any).x)
+        .attr('y1', d => (d.source as any).y)
+        .attr('x2', d => (d.target as any).x)
+        .attr('y2', d => (d.target as any).y);
+
+      node.attr('transform', d => `translate(${(d as any).x - 70}, ${(d as any).y - 20})`);
+    });
+
   }, []);
 
-  return (
-    <svg width="100%" height="500px" style={{ border: '1px solid #ccc' }}>
-      <text x="50%" y="50%" dominantBaseline="middle" textAnchor="middle" fontSize="20" fill="#888">
-        UVM Visualizer Placeholder
-      </text>
-    </svg>
-  );
+  return <svg ref={svgRef} width="100%" height="600px" style={{ border: '1px solid #ccc' }} />;
 };
 
 export default UvmTestbenchVisualizer;


### PR DESCRIPTION
This commit replaces the placeholder SVG in the `UvmTestbenchVisualizer` component with a static, force-directed graph rendered using D3.js. This provides the foundational visual representation of the UVM testbench architecture.

The implementation includes:
- A `useEffect` hook to manage the D3.js rendering lifecycle within the React component.
- A D3 force simulation (`d3.forceSimulation`) to automatically position component nodes and links.
- Data-binding of the `uvmComponents` array to render `<g>` elements for each component, containing a `<rect>` and a `<text>`.
- Data-binding of the `uvmConnections` array to render `<line>` elements for each connection, styled based on the connection type (parent_child, seq_item, analysis).

This completes the initial static rendering of the diagram, setting the stage for future interactivity.