### PR TITLE
Update tests for curriculum slugs

### DIFF
--- a/tests/e2e/curriculum-links.spec.ts
+++ b/tests/e2e/curriculum-links.spec.ts
@@ -9,10 +9,8 @@ test('should successfully load all curriculum pages and have correct titles', as
         const url = `/curriculum/${courseModule.slug}/${section.slug}/${topic.slug}`;
 
         await test.step(`checking ${url}`, async () => {
-          await page.goto(url);
-
-          const response = await page.waitForResponse(url);
-          expect(response.status()).toBe(200);
+          const response = await page.goto(url);
+          expect(response?.status()).toBe(200);
 
           const heading = page.locator('h1');
           await expect(heading).toHaveText(topic.title);

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -1,10 +1,10 @@
 import { test, expect } from '@playwright/test';
 
-test('factory link navigates to phasing page', async ({ page }) => {
+test('factory page next link navigates to component communication page', async ({ page }) => {
   await page.goto('/curriculum/uvm-core/fundamentals/factory');
-  await page.click('a:has-text("Phasing")');
-  await expect(page).toHaveURL('/curriculum/uvm-core/fundamentals/phasing');
-  await expect(page.locator('h1')).toContainText('Phasing');
+  await page.click('a:has-text("Component Communication")');
+  await expect(page).toHaveURL('/curriculum/uvm-core/fundamentals/component-communication');
+  await expect(page.locator('h1')).toContainText('Component Communication');
 });
 
 


### PR DESCRIPTION
## Summary
- update navigation test to follow new curriculum order
- update curriculum links test to check response directly via `page.goto`

## Testing
- `npx playwright install` *(failed: domain forbidden)*
- `npx playwright install-deps`
- `npm test` *(fails: 4 failed, 1 interrupted, 10 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688ca33490a88330aa543743029f65a1