### PR TITLE
Update tests for curriculum slugs

### DIFF
--- a/src/app/curriculum/page.tsx
+++ b/src/app/curriculum/page.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { curriculumData, getModules } from '@/lib/curriculum-data';
 import { TierSection } from '@/components/curriculum/TierSection';
-import { useCurriculumProgress } from '@/hooks/useCurriculumProgress';
+import { useCurriculumProgress } from '../../hooks/useCurriculumProgress';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Search, List, GitMerge } from 'lucide-react';
 import LearningPathDiagram from '@/components/curriculum/LearningPathDiagram';

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { useCurriculumProgress } from '@/hooks/useCurriculumProgress';
+import { useCurriculumProgress } from '../../hooks/useCurriculumProgress';
 import { curriculumData, getModules } from '@/lib/curriculum-data';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Progress } from '@/components/ui/Progress';

--- a/src/components/curriculum/Recommendations.tsx
+++ b/src/components/curriculum/Recommendations.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { curriculumData, getModules } from '@/lib/curriculum-data';
-import { useCurriculumProgress } from '@/hooks/useCurriculumProgress';
+import { useCurriculumProgress } from '../../hooks/useCurriculumProgress';
 import { ModuleCard } from './ModuleCard';
 import { ArrowRight } from 'lucide-react';
 

--- a/tests/e2e/curriculum-links.spec.ts
+++ b/tests/e2e/curriculum-links.spec.ts
@@ -9,10 +9,8 @@ test('should successfully load all curriculum pages and have correct titles', as
         const url = `/curriculum/${courseModule.slug}/${section.slug}/${topic.slug}`;
 
         await test.step(`checking ${url}`, async () => {
-          await page.goto(url);
-
-          const response = await page.waitForResponse(url);
-          expect(response.status()).toBe(200);
+          const response = await page.goto(url);
+          expect(response?.status()).toBe(200);
 
           const heading = page.locator('h1');
           await expect(heading).toHaveText(topic.title);

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -1,10 +1,10 @@
 import { test, expect } from '@playwright/test';
 
-test('factory link navigates to phasing page', async ({ page }) => {
+test('factory page next link navigates to component communication page', async ({ page }) => {
   await page.goto('/curriculum/uvm-core/fundamentals/factory');
-  await page.click('a:has-text("Phasing")');
-  await expect(page).toHaveURL('/curriculum/uvm-core/fundamentals/phasing');
-  await expect(page.locator('h1')).toContainText('Phasing');
+  await page.click('a:has-text("Component Communication")');
+  await expect(page).toHaveURL('/curriculum/uvm-core/fundamentals/component-communication');
+  await expect(page.locator('h1')).toContainText('Component Communication');
 });
 
 


### PR DESCRIPTION
## Summary
- update navigation test to follow new curriculum order
- update curriculum links test to check response directly via `page.goto`
- fix import paths for curriculum hooks

## Testing
- `npm run type-check`
- `npm test` *(fails: 15 failed)*

------
https://chatgpt.com/codex/tasks/task_e_688ca33490a88330aa543743029f65a1