### PR TITLE
Fix MDX page build issue and adjust title test

### DIFF
--- a/content/curriculum/T3_Advanced/A-UVM-1_Advanced_Sequencing/index.mdx
+++ b/content/curriculum/T3_Advanced/A-UVM-1_Advanced_Sequencing/index.mdx
@@ -33,7 +33,7 @@ In this example, a virtual sequence (`virtual_test_seq`) will coordinate two age
   code={`
 // High-level virtual sequence
 class virtual_test_seq extends uvm_sequence;
-  `uvm_object_utils(virtual_test_seq)
+  \\\`uvm_object_utils(virtual_test_seq)
 
   // Handles to the target sequencers
   config_sequencer_h config_sqr;

--- a/tests/e2e/curriculum-links.spec.ts
+++ b/tests/e2e/curriculum-links.spec.ts
@@ -12,7 +12,7 @@ test('should successfully load all curriculum pages and have correct titles', as
           const response = await page.goto(url);
           expect(response?.status()).toBe(200);
 
-          const heading = page.locator('h1');
+          const heading = page.locator('h1').first();
           await expect(heading).toHaveText(topic.title);
         });
       }


### PR DESCRIPTION
## Summary
- escape backticks in advanced sequencing MDX page so it compiles
- check the first `h1` element when verifying curriculum page titles

## Testing
- `npm test` *(fails: browserType.launch executable doesn't exist)*
- `npx playwright install --with-deps` *(fails: Download failed – domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688cf1955a0c8330a72c8e437f3a5907