### PR TITLE
feat: add simulation backend and environment

### DIFF
--- a/src/app/api/simulate/route.ts
+++ b/src/app/api/simulate/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+import { runSimulation } from '@/server/simulation';
+
+export async function POST(request: Request) {
+  const { code } = await request.json();
+  try {
+    const result = await runSimulation(code);
+    return NextResponse.json(result);
+  } catch (err) {
+    return NextResponse.json({ error: String(err) }, { status: 500 });
+  }
+}

--- a/src/components/ui/CodeExecutionEnvironment.tsx
+++ b/src/components/ui/CodeExecutionEnvironment.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Button } from './Button';
-import { Play } from 'lucide-react';
+import { Play, Pause, RotateCcw, StepForward } from 'lucide-react';
+import * as WaveDrom from 'wavedrom';
 
 interface CodeExecutionEnvironmentProps {
   // In the future, this might take the code as a prop, e.g.
@@ -11,55 +12,115 @@ interface CodeExecutionEnvironmentProps {
 
 export const CodeExecutionEnvironment: React.FC<CodeExecutionEnvironmentProps> = () => {
   const [isRunning, setIsRunning] = useState(false);
+  const [isPaused, setIsPaused] = useState(false);
   const [output, setOutput] = useState<string>('');
+  const [coverage, setCoverage] = useState<number | null>(null);
+  const [regressions, setRegressions] = useState<string[]>([]);
+  const [waveform, setWaveform] = useState<any>(null);
+  const [stats, setStats] = useState<{ runtimeMs: number; memoryBytes: number } | null>(null);
+  const waveRef = useRef<HTMLDivElement>(null);
 
-  const handleRunCode = () => {
+  useEffect(() => {
+    if (waveform && waveRef.current) {
+      WaveDrom.renderWaveElement(waveRef.current, waveform);
+    }
+  }, [waveform]);
+
+  const handleRunCode = async () => {
     setIsRunning(true);
+    setIsPaused(false);
     setOutput('Compiling and running simulation...');
 
-    // Simulate a network request or a long-running process like a simulation
-    setTimeout(() => {
-      const mockOutput = [
-        'VCS-MX/MXI-2023.03-SP2-1  linux-64  Jul 26 15:00 2023',
-        'Copyright (c) 1991-2023.  ALL RIGHTS RESERVED.',
-        'info: Running test: base_test',
-        '-----------------------------------',
-        'UVM_INFO @ 0: uvm_test_top [RNTST] Starting test base_test',
-        'UVM_INFO @ 10: uvm_test_top.env.agent [AGENT] Got item: 5',
-        'UVM_INFO @ 20: uvm_test_top.env.agent [AGENT] Got item: 12',
-        'UVM_INFO @ 30: uvm_test_top.env.agent [AGENT] Got item: 8',
-        '--- UVM Report Summary ---',
-        '** Report counts by severity',
-        'UVM_INFO : 4',
-        'UVM_WARNING : 0',
-        'UVM_ERROR : 0',
-        'UVM_FATAL : 0',
-        '** Report counts by id',
-        '[AGENT] 3',
-        '[RNTST] 1',
-        '',
-        'Simulation PASSED',
-      ].join('\n');
-
-      setOutput(mockOutput);
+    try {
+      const res = await fetch('/api/simulate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code: '' }),
+      });
+      const data = await res.json();
+      setOutput(data.output);
+      setWaveform(data.waveform);
+      setStats(data.stats);
+      setCoverage(data.coverage);
+      setRegressions(data.regressions || []);
+    } catch (err) {
+      setOutput(String(err));
+    } finally {
       setIsRunning(false);
-    }, 2000);
+    }
+  };
+
+  const handlePause = () => {
+    setIsPaused((p) => !p);
+    // In a real implementation, this would signal the simulator
+    // to pause or resume execution.
+  };
+
+  const handleStep = () => {
+    // Placeholder for stepping through simulation cycles.
+  };
+
+  const handleReset = () => {
+    setOutput('');
+    setWaveform(null);
+    setStats(null);
+    setCoverage(null);
+    setRegressions([]);
   };
 
   return (
     <div className="code-execution-environment my-6 p-4 border border-white/20 rounded-lg shadow-md bg-white/10 backdrop-blur-lg">
-      <div className="controls mb-4">
+      <div className="controls mb-4 flex gap-2">
         <Button onClick={handleRunCode} disabled={isRunning}>
           <Play className="w-4 h-4 mr-2" />
-          {isRunning ? 'Running...' : 'Run Simulation'}
+          {isRunning ? 'Running...' : 'Run'}
+        </Button>
+        <Button onClick={handlePause} disabled={!isRunning} variant="secondary">
+          <Pause className="w-4 h-4 mr-2" />
+          {isPaused ? 'Resume' : 'Pause'}
+        </Button>
+        <Button onClick={handleStep} disabled={!isRunning} variant="secondary">
+          <StepForward className="w-4 h-4 mr-2" />Step
+        </Button>
+        <Button onClick={handleReset} variant="secondary">
+          <RotateCcw className="w-4 h-4 mr-2" />Reset
         </Button>
       </div>
-      <div className="output-section">
+      <div className="output-section mb-4">
         <h3 className="text-lg font-semibold mb-2 text-foreground/90">Simulation Output</h3>
         <pre className="bg-black text-white p-4 rounded-md text-sm whitespace-pre-wrap font-mono h-64 overflow-y-auto">
-          {output || 'Click "Run Simulation" to see the output.'}
+          {output || 'Click "Run" to see the output.'}
         </pre>
       </div>
+      {waveform && (
+        <div className="waveform-section mb-4">
+          <h3 className="text-lg font-semibold mb-2 text-foreground/90">Waveform</h3>
+          <div ref={waveRef} />
+        </div>
+      )}
+      {stats && (
+        <div className="profiling-section mb-4 text-sm">
+          <h3 className="text-lg font-semibold mb-2 text-foreground/90">Performance</h3>
+          <p>Runtime: {stats.runtimeMs.toFixed(2)} ms</p>
+          <p>Memory: {Math.round(stats.memoryBytes / 1024)} kB</p>
+        </div>
+      )}
+      {coverage !== null && (
+        <div className="coverage-section mb-4 text-sm">
+          <h3 className="text-lg font-semibold mb-2 text-foreground/90">Coverage</h3>
+          <p>{coverage}%</p>
+        </div>
+      )}
+      {regressions.length > 0 && (
+        <div className="regression-section text-sm">
+          <h3 className="text-lg font-semibold mb-2 text-foreground/90">Regression Results</h3>
+          <ul className="list-disc pl-5">
+            {regressions.map((r, idx) => (
+              <li key={idx}>{r}</li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/server/simulation/index.ts
+++ b/src/server/simulation/index.ts
@@ -1,0 +1,54 @@
+import { spawn } from 'child_process';
+import { SimulationResult, SimulationStats } from './types';
+
+/**
+ * Executes a SystemVerilog simulation inside a containerised open-source
+ * simulator. The current implementation uses a very lightweight bash script as
+ * a placeholder but is structured so that tools like Icarus Verilog or
+ * Verilator (via Docker or WebAssembly) can be dropped in with minimal
+ * changes.
+ */
+export async function runSimulation(source: string): Promise<SimulationResult> {
+  const start = process.hrtime.bigint();
+
+  return new Promise((resolve, reject) => {
+    // Placeholder command: echo compilation and simulation messages.
+    const proc = spawn('bash', ['-lc', 'echo "Compiling..." && sleep 1 && echo "Running..." && sleep 1 && echo "Done"']);
+
+    let output = '';
+    proc.stdout.on('data', (d) => {
+      output += d.toString();
+    });
+    proc.stderr.on('data', (d) => {
+      output += d.toString();
+    });
+
+    proc.on('error', (err) => {
+      reject(err);
+    });
+
+    proc.on('close', () => {
+      const end = process.hrtime.bigint();
+      const stats: SimulationStats = {
+        runtimeMs: Number(end - start) / 1e6,
+        memoryBytes: process.memoryUsage().rss,
+      };
+
+      // Simple demo waveform
+      const waveform = {
+        signal: [
+          { name: 'clk', wave: 'p.....|...' },
+          { name: 'data', wave: 'x3.4..|x.' },
+        ],
+      };
+
+      resolve({
+        output,
+        waveform,
+        stats,
+        coverage: 0,
+        regressions: [],
+      });
+    });
+  });
+}

--- a/src/server/simulation/types.ts
+++ b/src/server/simulation/types.ts
@@ -1,0 +1,19 @@
+export interface SimulationStats {
+  /** Total runtime in milliseconds */
+  runtimeMs: number;
+  /** Resident set size in bytes */
+  memoryBytes: number;
+}
+
+export interface SimulationResult {
+  /** Combined stdout/stderr output from the simulator */
+  output: string;
+  /** Waveform JSON suitable for WaveDrom rendering */
+  waveform: unknown;
+  /** Aggregate performance and resource metrics */
+  stats: SimulationStats;
+  /** Code coverage percentage reported by the simulator */
+  coverage: number;
+  /** Any regression failures collected during execution */
+  regressions: string[];
+}


### PR DESCRIPTION
## Summary
- add placeholder simulation backend service for future WebAssembly or container simulators
- expose /api/simulate endpoint
- enhance CodeExecutionEnvironment with waveform viewer, debugging controls, and profiling metrics

## Testing
- `npm test` *(fails: tests/e2e/... 19 failed)*
- `npm run type-check` *(fails: TS errors in unrelated files)*
- `npx eslint src/components/ui/CodeExecutionEnvironment.tsx src/server/simulation/index.ts src/server/simulation/types.ts src/app/api/simulate/route.ts`

------
https://chatgpt.com/codex/tasks/task_e_6892510eec88833086cc0b1a88d9141c