### PR TITLE
Add analysis, collaboration and learning stubs

### DIFF
--- a/src/lib/analysis.ts
+++ b/src/lib/analysis.ts
@@ -1,0 +1,66 @@
+import * as acorn from "acorn";
+
+export interface AnalysisResult {
+  dependencies: string[];
+  performance: Record<string, number>;
+}
+
+/**
+ * Parse source code into an AST using acorn.
+ */
+export function parseAST(code: string) {
+  return acorn.parse(code, { ecmaVersion: "latest", sourceType: "module" });
+}
+
+/**
+ * Very lightweight pattern matcher that checks whether the serialized AST
+ * contains the provided pattern string. This is a placeholder for a real
+ * pattern matching engine.
+ */
+export function matchPattern(ast: unknown, pattern: string): boolean {
+  return JSON.stringify(ast).includes(pattern);
+}
+
+/**
+ * Recursively walk the AST collecting module dependencies from import
+ * declarations. This intentionally avoids external traversal libraries to
+ * keep the example self-contained.
+ */
+export function analyzeDependencies(ast: any): string[] {
+  const deps: string[] = [];
+  (function walk(node: any) {
+    if (node && typeof node === "object") {
+      if (node.type === "ImportDeclaration" && node.source?.value) {
+        deps.push(String(node.source.value));
+      }
+      for (const key of Object.keys(node)) {
+        const value = (node as any)[key];
+        if (Array.isArray(value)) {
+          value.forEach(walk);
+        } else if (value && typeof value === "object") {
+          walk(value);
+        }
+      }
+    }
+  })(ast);
+  return deps;
+}
+
+/**
+ * Produce a naive timing prediction for each module. In a real system this
+ * would use historical run data or static analysis to estimate cost.
+ */
+export function predictTiming(modules: string[]): Record<string, number> {
+  const result: Record<string, number> = {};
+  for (const mod of modules) {
+    result[mod] = mod.length;
+  }
+  return result;
+}
+
+export function analyzeSource(code: string): AnalysisResult {
+  const ast = parseAST(code);
+  const dependencies = analyzeDependencies(ast);
+  const performance = predictTiming(dependencies);
+  return { dependencies, performance };
+}

--- a/src/lib/collaboration.ts
+++ b/src/lib/collaboration.ts
@@ -1,0 +1,31 @@
+export interface UserEdit {
+  user: string;
+  content: string;
+  timestamp: number;
+}
+
+/**
+ * Establish a simple WebSocket connection for collaboration. The URL is
+ * expected to point to a collaboration service.
+ */
+export function connectCollaboration(url: string): WebSocket {
+  const socket = new WebSocket(url);
+  return socket;
+}
+
+/**
+ * Send an edit event to the collaboration server so other users receive the
+ * update. This is a placeholder; a real implementation would likely include
+ * operational transform or CRDT logic.
+ */
+export function broadcastEdit(socket: WebSocket, edit: UserEdit) {
+  socket.send(JSON.stringify({ type: "edit", edit }));
+}
+
+/**
+ * Integrate with a version-control system by returning a commit-like object.
+ * The current implementation simply wraps the content and user information.
+ */
+export function createVersion(edit: UserEdit) {
+  return { message: `edit by ${edit.user}`, content: edit.content };
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,1 +1,4 @@
-export * from './curriculum-data';
+export * from "./analysis";
+export * from "./collaboration";
+export * from "./curriculum-data";
+export * from "./learning";

--- a/src/lib/learning.ts
+++ b/src/lib/learning.ts
@@ -1,0 +1,48 @@
+export interface UserProfile {
+  id: string;
+  level: number;
+  completed: string[];
+}
+
+export interface AssessmentRecord {
+  score: number;
+  topic: string;
+  timestamp: number;
+}
+
+/**
+ * Generate a simple learning path by recommending the next module based on
+ * the user's current level and completed content.
+ */
+export function generateLearningPath(profile: UserProfile): string[] {
+  const nextLevel = profile.level + 1;
+  return [`module-${nextLevel}`];
+}
+
+/**
+ * Provide an adaptive challenge tailored to the learner's level. In this
+ * placeholder implementation we simply return a string referencing the level.
+ */
+export function getAdaptiveChallenge(profile: UserProfile): string {
+  return `challenge-for-level-${profile.level}`;
+}
+
+/**
+ * Append an assessment record for analytics purposes.
+ */
+export function recordAssessment(
+  history: AssessmentRecord[],
+  record: AssessmentRecord,
+): AssessmentRecord[] {
+  return [...history, record];
+}
+
+/**
+ * Predict learner progress as a numeric metric between 0 and 1 by averaging
+ * assessment scores.
+ */
+export function predictProgress(history: AssessmentRecord[]): number {
+  if (history.length === 0) return 0;
+  const total = history.reduce((acc, r) => acc + r.score, 0);
+  return total / (history.length * 100);
+}


### PR DESCRIPTION
## Summary
- stub AST analysis utilities for pattern matching, dependency scanning and timing prediction
- stub WebSocket collaboration helpers and version creation
- stub personalized learning helpers for paths, challenges and progress

## Testing
- `npm test` *(fails: browserType.launch: Target page, context or browser has been closed)*
- `npx playwright install --with-deps` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_689251158d008330894c6faa4bd67266