### PR TITLE
feat: add selectable simulator backend

### DIFF
--- a/src/app/api/simulate/route.ts
+++ b/src/app/api/simulate/route.ts
@@ -2,9 +2,9 @@ import { NextResponse } from 'next/server';
 import { runSimulation } from '@/server/simulation';
 
 export async function POST(request: Request) {
-  const { code } = await request.json();
+  const { code, backend } = await request.json();
   try {
-    const result = await runSimulation(code);
+    const result = await runSimulation(code, backend);
     return NextResponse.json(result);
   } catch (err) {
     return NextResponse.json({ error: String(err) }, { status: 500 });

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -8,7 +8,13 @@ import Logo from "@/components/ui/Logo";
 import { ThemeSwitcher } from "@/components/ui/ThemeSwitcher";
 import { useNavigation } from "@/contexts/NavigationContext";
 
-const navLinks = [
+interface NavLink {
+  label: string;
+  href: string;
+  dropdown?: { label: string; href: string }[];
+}
+
+const navLinks: NavLink[] = [
   {
     label: "Curriculum",
     href: "/curriculum",

--- a/src/components/templates/InfoPage.tsx
+++ b/src/components/templates/InfoPage.tsx
@@ -22,6 +22,7 @@ const DiagramPlaceholder = ({ title = "Diagram" }: { title?: string }) => (
 
 interface InfoPageProps {
   title?: string;
+  description?: string;
   children: ReactNode; // Main content of the page
   // Optional slots for specific types of content
   charts?: ReactNode[];
@@ -30,6 +31,7 @@ interface InfoPageProps {
 
 export const InfoPage: React.FC<InfoPageProps> = ({
   title,
+  description,
   children,
   charts,
   diagrams,
@@ -38,12 +40,15 @@ export const InfoPage: React.FC<InfoPageProps> = ({
     <div className="container mx-auto py-8 px-4">
       <div className="p-4 md:p-6 bg-white/10 backdrop-blur-lg border border-white/20 rounded-lg shadow-lg">
         <article className="prose dark:prose-invert lg:prose-xl max-w-none">
-          {/*
-          Using Tailwind Typography (prose classes) for rich text formatting.
-          Ensure @tailwindcss/typography plugin is installed if not already.
-          The 'max-w-none' removes the default max-width from prose for full container width.
-          Adjust 'lg:prose-xl' for desired text size.
-        */}
+          {title && (
+            <header className="mb-8">
+              <h1 className="text-4xl font-bold mb-2">{title}</h1>
+              {description && (
+                <p className="text-foreground/80 text-lg">{description}</p>
+              )}
+            </header>
+          )}
+
           <section className="mb-8">
             {children}
           </section>

--- a/src/server/simulation/types.ts
+++ b/src/server/simulation/types.ts
@@ -3,7 +3,13 @@ export interface SimulationStats {
   runtimeMs: number;
   /** Resident set size in bytes */
   memoryBytes: number;
+  /** User CPU time in milliseconds */
+  cpuUserMs: number;
+  /** System CPU time in milliseconds */
+  cpuSystemMs: number;
 }
+
+export type SimulatorBackend = 'wasm' | 'icarus' | 'verilator';
 
 export interface SimulationResult {
   /** Combined stdout/stderr output from the simulator */
@@ -16,4 +22,6 @@ export interface SimulationResult {
   coverage: number;
   /** Any regression failures collected during execution */
   regressions: string[];
+  /** Backend used for the simulation */
+  backend: SimulatorBackend;
 }

--- a/tests/e2e/interactive-demo.spec.ts
+++ b/tests/e2e/interactive-demo.spec.ts
@@ -32,10 +32,14 @@ test.describe('Interactive Demo Page', () => {
     const outputPanel = page.locator('pre');
     await expect(outputPanel).toContainText('Click "Run Simulation" to see the output.');
 
+    // Run with default backend
     await page.getByRole('button', { name: 'Run Simulation' }).click();
-
-    // Wait for the simulation to "complete"
     await expect(outputPanel).toContainText('Simulation PASSED', { timeout: 3000 });
+
+    // Switch backend and run again to ensure selection works
+    await page.locator('select').selectOption('verilator');
+    await page.getByRole('button', { name: 'Run Simulation' }).click();
+    await expect(outputPanel).toContainText('[Verilator] Running', { timeout: 3000 });
   });
 
   test('should display the placeholder components', async ({ page }) => {


### PR DESCRIPTION
## Summary
- support multiple simulation backends with basic resource metrics
- expose backend selector and profiling details in CodeExecutionEnvironment
- render InfoPage headers and type nav links

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test` *(fails: 19 failed)*


------
https://chatgpt.com/codex/tasks/task_e_6892d4fd32cc8330b9c17e120e1ac5d8