### PR TITLE
feat: add collaboration, learning and analytics modules

### DIFF
--- a/src/components/analytics/AnalyticsDashboard.tsx
+++ b/src/components/analytics/AnalyticsDashboard.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import React from 'react';
+import {
+  computeCompetency,
+  computeEngagement,
+  predictPerformance,
+  type AnalyticsEvent,
+} from '../../lib/analytics';
+
+interface AnalyticsDashboardProps {
+  events: AnalyticsEvent[];
+}
+
+export const AnalyticsDashboard: React.FC<AnalyticsDashboardProps> = ({ events }) => {
+  const competency = computeCompetency(events).toFixed(2);
+  const engagement = computeEngagement(events);
+  const performance = predictPerformance(events).toFixed(2);
+  return (
+    <div className="p-4 border rounded">
+      <h3 className="font-semibold mb-2">Learning Analytics</h3>
+      <ul className="text-sm list-disc ml-5">
+        <li>Competency: {competency}</li>
+        <li>Engagement events: {engagement}</li>
+        <li>Predicted performance: {performance}</li>
+      </ul>
+    </div>
+  );
+};
+
+export default AnalyticsDashboard;

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,34 @@
+export interface AnalyticsEvent {
+  type: 'assessment' | 'interaction';
+  value: number;
+  timestamp: number;
+}
+
+/** Record an analytics event */
+export function recordEvent(
+  history: AnalyticsEvent[],
+  event: AnalyticsEvent,
+): AnalyticsEvent[] {
+  return [...history, event];
+}
+
+/** Average assessment scores to represent competency */
+export function computeCompetency(history: AnalyticsEvent[]): number {
+  const assessments = history.filter(e => e.type === 'assessment');
+  if (assessments.length === 0) return 0;
+  return assessments.reduce((acc, e) => acc + e.value, 0) / assessments.length;
+}
+
+/** Count of interaction events as engagement metric */
+export function computeEngagement(history: AnalyticsEvent[]): number {
+  return history.filter(e => e.type === 'interaction').length;
+}
+
+/**
+ * Predict performance by combining competency and engagement in a naive model
+ */
+export function predictPerformance(history: AnalyticsEvent[]): number {
+  const competency = computeCompetency(history);
+  const engagement = computeEngagement(history);
+  return competency * (1 + engagement / 10);
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -2,3 +2,4 @@ export * from "./analysis";
 export * from "./collaboration";
 export * from "./curriculum-data";
 export * from "./learning";
+export * from "./analytics";


### PR DESCRIPTION
## Summary
- add websocket collaboration and review log to InteractiveCode
- expand learning utilities for progress tracking and challenge recommendations
- introduce basic analytics module and dashboard component

## Testing
- `npm test` *(fails: tests/e2e/curriculum-integrity.spec.ts, tests/e2e/curriculum-links.spec.ts, tests/e2e/curriculum-nav.spec.ts, tests/e2e/interactive-demo.spec.ts, tests/e2e/labs.spec.ts, tests/e2e/mobile-navigation.spec.ts, tests/e2e/module5.spec.ts, tests/e2e/navigation.spec.ts, tests/e2e/simple-test.spec.ts, tests/e2e/theming.spec.ts)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892d50436788330b5f38531a2bd6290