### PR TITLE
docs: add CodeReviewAssistant documentation

### DIFF
--- a/docs/components/CodeReviewAssistant.md
+++ b/docs/components/CodeReviewAssistant.md
@@ -1,0 +1,34 @@
+# CodeReviewAssistant
+
+The `CodeReviewAssistant` component provides a lightweight, client-side simulation of a typical peer-review workflow. It bundles automated checks for documentation, tests, architecture, and coding standards while allowing reviewers to leave comments and approve a commit.
+
+## Custom Hooks
+
+Each automated check is implemented as a custom React hook that returns a `CheckResult` object containing a `status` (`"pending" | "pass" | "fail"`) and optional `details` text.
+
+- **`useDocumentationCheck()`** – Resolves after a short delay to report whether modules are documented.
+- **`useTestCoverageCheck()`** – Simulates a test coverage verification.
+- **`useArchitectureCheck()`** – Confirms that architectural patterns are followed.
+- **`useCodingStandardsCheck()`** – Verifies adherence to the project's style guide.
+
+All hooks take no arguments and are purely illustrative; they would typically accept configuration or data about the commit under review.
+
+## Peer‑Review Workflow
+
+1. **Commit ID** – Reviewers supply the hash of the commit being inspected.
+2. **Comments** – Reviewers can leave multiple textual comments which are listed below the form.
+3. **Approval Toggle** – Once satisfied, the reviewer can mark the review as approved. A confirmation message appears when approval is set.
+
+## Usage Example
+
+The component is showcased on the [Interactive Demo page](../../src/app/practice/interactive-demo/page.tsx) where it is rendered without props:
+
+```tsx
+import { CodeReviewAssistant } from '@/components/ui/CodeReviewAssistant';
+
+// …within the page component
+<CodeReviewAssistant />
+```
+
+This demo illustrates how the assistant might be embedded alongside other interactive learning tools.
+

--- a/src/components/ui/CodeReviewAssistant.tsx
+++ b/src/components/ui/CodeReviewAssistant.tsx
@@ -16,6 +16,10 @@ type CheckResult = {
   details?: string;
 };
 
+/**
+ * Simulates a documentation completeness check for the current commit.
+ * @returns {CheckResult} asynchronous status and optional details once the check resolves.
+ */
 export const useDocumentationCheck = (): CheckResult => {
   const [result, setResult] = React.useState<CheckResult>({ status: "pending" });
   React.useEffect(() => {
@@ -27,6 +31,10 @@ export const useDocumentationCheck = (): CheckResult => {
   return result;
 };
 
+/**
+ * Simulates verifying the project's overall test coverage.
+ * @returns {CheckResult} asynchronous status and optional coverage information.
+ */
 export const useTestCoverageCheck = (): CheckResult => {
   const [result, setResult] = React.useState<CheckResult>({ status: "pending" });
   React.useEffect(() => {
@@ -38,6 +46,10 @@ export const useTestCoverageCheck = (): CheckResult => {
   return result;
 };
 
+/**
+ * Pretends to validate that architectural guidelines are followed in the codebase.
+ * @returns {CheckResult} asynchronous status and optional architecture notes.
+ */
 export const useArchitectureCheck = (): CheckResult => {
   const [result, setResult] = React.useState<CheckResult>({ status: "pending" });
   React.useEffect(() => {
@@ -49,6 +61,10 @@ export const useArchitectureCheck = (): CheckResult => {
   return result;
 };
 
+/**
+ * Mimics a coding standards linter that ensures style guide adherence.
+ * @returns {CheckResult} asynchronous status and optional lint details.
+ */
 export const useCodingStandardsCheck = (): CheckResult => {
   const [result, setResult] = React.useState<CheckResult>({ status: "pending" });
   React.useEffect(() => {
@@ -64,6 +80,10 @@ export const useCodingStandardsCheck = (): CheckResult => {
 // Component
 // ---------------------------------------------------------------------------
 
+/**
+ * Aggregates automated code quality checks and a minimal peer-review interface.
+ * The component has no props and maintains its own state for comments and approval.
+ */
 export const CodeReviewAssistant = () => {
   // Automated check results
   const [quality, setQuality] = React.useState<CheckResult>({ status: "pending" });


### PR DESCRIPTION
## Summary
- document CodeReviewAssistant component and its peer-review workflow
- add JSDoc comments for automated review hooks

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892e247d6e883308692565119191bbe