### PR TITLE
test: add CodeReviewAssistant interactions

### DIFF
--- a/tests/components/CodeReviewAssistant.test.tsx
+++ b/tests/components/CodeReviewAssistant.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect } from 'vitest';
+import CodeReviewAssistant from '../../src/components/ui/CodeReviewAssistant';
+
+describe('CodeReviewAssistant component', () => {
+  it('shows commit id after typing', async () => {
+    render(<CodeReviewAssistant />);
+    const input = screen.getByPlaceholderText(/commit id/i);
+    await userEvent.type(input, 'abc123');
+    const message = await screen.findByText(/reviewing commit/i);
+    expect(message).toHaveTextContent('abc123');
+  });
+
+  it('adds trimmed comments and toggles approval', async () => {
+    render(<CodeReviewAssistant />);
+
+    const textarea = screen.getByPlaceholderText(/leave a comment/i);
+    const addButton = screen.getByRole('button', { name: /add comment/i });
+
+    await userEvent.type(textarea, '  first comment  ');
+    await userEvent.click(addButton);
+    const list = screen.getByText('first comment').closest('ul')!;
+    expect(within(list).getByText('first comment')).toBeInTheDocument();
+
+    await userEvent.type(textarea, 'second comment');
+    await userEvent.click(addButton);
+    const items = within(list).getAllByRole('listitem');
+    expect(items.map((li) => li.textContent)).toEqual(['first comment', 'second comment']);
+
+    const approveButton = screen.getByRole('button', { name: /approve/i });
+    await userEvent.click(approveButton);
+    expect(approveButton).toHaveTextContent('Approved');
+    expect(screen.getByText(/review approved/i)).toBeInTheDocument();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- configure vitest with jsdom environment and `@` alias
- test CodeReviewAssistant commit ID input, comment list, and approval toggle

## Testing
- `npx vitest run tests/quiz.spec.tsx tests/srs.spec.ts tests/components/CodeReviewAssistant.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6892e247db1c8330b13c5e95b8ecee00