### PR TITLE
docs: expand verification intro with tools and exercises

### DIFF
--- a/content/curriculum/T1_Foundational/F1_Why_Verification/index.mdx
+++ b/content/curriculum/T1_Foundational/F1_Why_Verification/index.mdx
@@ -118,6 +118,45 @@ Let's take the `and_gate` example and see how you would actually run it using a 
     ```
     This simple feedback loop is the core of all verification: drive stimulus, observe output, and check for correctness. In a real project, this process is automated with scripts and checkers that report failures automatically.
 
+## Tool Integration
+
+Selecting and using simulators effectively is a key verification skill. Below are common tools and how to invoke them on the `and_gate` example.
+
+### Simulator Commands
+
+- **Synopsys VCS**
+```bash
+vcs -sverilog tb_and_gate.sv and_gate.v -o simv
+./simv
+```
+- **Siemens Questa**
+```bash
+vlog and_gate.v tb_and_gate.sv
+vsim -c tb_and_gate -do "run -all; quit"
+```
+- **Cadence Xcelium**
+```bash
+xrun tb_and_gate.sv and_gate.v
+```
+
+### Build-System Examples
+
+A simple Makefile target can streamline repeated runs:
+
+```makefile
+sim:
+    vcs -sverilog tb_and_gate.sv and_gate.v -o simv && ./simv
+```
+
+Or a shell script:
+
+```bash
+#!/bin/sh
+xrun tb_and_gate.sv and_gate.v -access +r
+```
+
+For deeper dives into each tool, see the [Further Learning](#further-learning) section.
+
 ## Level 3: Expert Insights
 
 **Verification is not just about finding bugs; it's about *preventing* them.** A great verification engineer doesn't just write tests. They become a "power user" of the design. They read the specification, question it, and collaborate with designers to clarify ambiguity *before* a single line of RTL is written. This proactive approach is infinitely more valuable than finding bugs later.
@@ -184,6 +223,24 @@ To dive deeper into the world of verification, consider these resources:
     *   Attend or read papers from the **Design Automation Conference (DAC)** and the **DVCon (Design and Verification Conference)**. These are the premier events where new tools and techniques are presented.
 *   **Online Communities:**
     *   Engage with forums on sites like **Verification Academy** and the **UVMWorld forums**.
+
+---
+
+## Self-Assessment
+
+Put your knowledge into practice with these exercises:
+
+1. **Code Challenge:** Extend the `tb_and_gate` testbench to automatically check all four input combinations and report mismatches.
+2. **Debugging Exercise:** The snippet below never toggles `clk`. Identify and fix the problem.
+   ```systemverilog
+   initial begin
+     logic clk;
+     forever #5 clk = ~clk;
+   end
+   ```
+3. **Code Review Task:** Review a peer's testbench and look for uninitialized signals or missing assertions.
+
+After completing these tasks, explore the [Further Learning](#further-learning) resources for more practice.
 
 ---
 


### PR DESCRIPTION
## Summary
- add **Tool Integration** section outlining commands for VCS, Questa, and Xcelium plus Makefile/shell build examples
- add **Self-Assessment** section with code challenge, debugging exercise, and code-review task

## Testing
- `npm test` *(fails: Playwright browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68931ec59448833084ad3fbe3bfd0881