### PR TITLE
docs: expand data types module with industry context

### DIFF
--- a/content/curriculum/T1_Foundational/F2_Data_Types/index.mdx
+++ b/content/curriculum/T1_Foundational/F2_Data_Types/index.mdx
@@ -72,6 +72,49 @@ The chart below compares key characteristics of `logic`, `wire`, `reg`, and `bit
 **Packed vs. Unpacked Arrays:** A common mistake is not understanding the memory layout. `packed` arrays are contiguous bits, treated as a single vector. `unpacked` arrays are more like arrays in software. You can't directly assign an unpacked array to a packed one. This is crucial for interfaces and when casting to/from other types.
 
 **Memory & Retention Tip:** Relate **4-state `logic`** to the *physical hardware world* where uncertainty (`X`, `Z`) is real. Relate **2-state `bit`** to the *idealized software world* of your testbench where variables are always well-defined.
+**War Story:** A seasoned verification lead once spent days chasing a phantom bug that turned out to be an uninitialized `logic` signal. Switching the variable to a 2-state `bit` in non-DUT code exposed the issue immediately and trimmed hours off regression time.
+
+**Common Pitfall:** Mixing packed and unpacked dimensions in the wrong order can silently change data layout. Always declare packed dimensions to the left of the variable name and unpacked dimensions to the right to avoid misaligned buses.
+
+**Performance Tip:** Use `bit [31:0]` for large scoreboards or counters. Simulators can optimize 2-state vectors, giving significant speedups compared to their 4-state counterparts.
+
+## Industry Connection
+
+In chip design companies, data type discipline directly affects simulation turnaround time and hardware fidelity. Verification teams tune their data type usage to balance accuracy with runtime, allowing faster iteration on complex SoCs.
+
+## Historical Context
+
+SystemVerilog inherited its 4-state logic from Verilog to model real-world electrical behavior. The addition of 2-state types reflected the industry's need for faster, software-like constructs as verification environments grew in complexity.
+
+## Career Impact
+
+Engineers who master data types write clearer testbenches and debug faster. Recruiters look for candidates who can explain when to choose `logic` over `wire` or `bit`, signaling practical understanding beyond syntax.
+
+## Practical Application
+
+Use `logic` for DUT-facing signals, `wire` for tri-state nets, and `bit` or `int` for testbench variables. For example, declare `logic [31:0] cfg_reg;` on an interface while using `int retry_count;` inside a class-based sequence.
+
+## Tool Integration
+
+Simulators, linters, and waveform viewers rely on accurate data type declarations. Properly typed signals produce clearer wave dumps and integrate seamlessly with coverage and assertion tools.
+
+## Common Interview Questions
+
+- What's the difference between a `wire` and `logic` in SystemVerilog?
+- How do packed and unpacked arrays affect memory layout?
+- When would you choose a 2-state type over a 4-state type?
+
+## Self-Assessment
+
+**Exercises**
+
+1. Declare an associative array that maps string opcodes to 8-bit `logic` vectors and write a loop to display its contents.
+2. Convert a 4-state `logic [7:0]` bus to a 2-state equivalent using `bit`, noting any changes in simulation results.
+
+**Debugging Tasks**
+
+1. Identify why a `logic` signal remains `X` after reset in a simple testbench and modify the code to resolve it.
+2. Given a packed struct passed through an interface, locate and fix a mismatch between packed and unpacked dimensions.
 
 ## Check Your Understanding
 


### PR DESCRIPTION
## Summary
- expand expert insights with war stories, pitfalls, and performance tips
- add industry, historical, career, and tool integration sections
- include self-assessment tasks and interview questions

## Testing
- `npm test` (fails: 19 failed)
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68931ec6a86083309042d0e85d3fcf37