### PR TITLE
docs: expand rtl and testbench constructs

### DIFF
--- a/content/curriculum/T1_Foundational/F4_RTL_and_Testbench_Constructs/index.mdx
+++ b/content/curriculum/T1_Foundational/F4_RTL_and_Testbench_Constructs/index.mdx
@@ -64,6 +64,53 @@ endinterface
 
 **Memory & Retention Tip:** Remember: **Module = The Box.** **Interface = The Cable.** **Package = The Library.**
 
+**War Story:** A team once linked a testbench to a design using dozens of individual signals. One missed connection kept a grant signal stuck low for weeks. Moving the same project to an `interface` eliminated that entire class of bugs and cut bring-up time in half.
+
+**Performance Implications:** Overusing `program` blocks can slow simulation because they serialize events. Clocking blocks, when used correctly, align stimulus and sampling to reduce race conditions and keep runs fast.
+
+**Optimization Tip:** Place common utility tasks and typedefs in packages and import them where needed. This reduces compile time and prevents duplicate code across the project.
+
+## Industry Connection
+
+Modern verification flows rely on these constructs to keep massive SoCs manageable. Interfaces drive AXI, PCIe, and other industry-standard protocols, while packages deliver consistent utilities across multi-site teams.
+
+---
+
+## Historical Context
+
+SystemVerilog evolved from separate Verilog and verification languages. Interfaces and packages were added in the 2005 standard to address the growing complexity of testbenches and design reuse.
+
+---
+
+## Career Impact
+
+Engineers fluent in RTL and testbench constructs are sought after for roles ranging from IP integration to verification architecture. Demonstrating mastery of packages and interfaces signals that you can build scalable, maintainable environments.
+
+---
+
+## Practical Application
+
+Try modeling a simple bus protocol. Use a package for shared types, an interface for the bus signals, and a clocking block to drive transactions from a program block or class-based environment.
+
+---
+
+## Tool Integration
+
+Simulators like VCS, Questa, and Xcelium fully support packages and interfaces, and static analysis tools can lint your use of clocking blocks and `program` regions to catch issues before simulation.
+
+---
+
+## Common Interview Questions
+
+**Q1: When would you prefer an `interface` over a traditional port list?**
+> **A1:** When multiple related signals are passed together or when you need tasks, functions, or clocking blocks alongside the signals.
+
+**Q2: What problem do clocking blocks solve?**
+> **A2:** They remove race conditions by defining exactly when signals are sampled and driven relative to a clock edge.
+
+**Q3: Why are packages important in a large verification environment?**
+> **A3:** They centralize shared declarations, preventing name collisions and keeping the codebase consistent across teams.
+
 ## Check Your Understanding
 
 <Quiz questions={[
@@ -88,3 +135,13 @@ endinterface
       "explanation": "Clocking blocks are used to ensure that the testbench samples DUT outputs and drives DUT inputs at predictable times relative to the clock edge, eliminating timing hazards."
     }
   ]} />
+
+## Self-Assessment Exercises
+
+1. Write a small design with two modules communicating through an `interface`. Observe how replacing individual port connections simplifies the top-level wiring.
+2. Create a package that defines a transaction class and reuse it in two different testbenches.
+
+## Debugging Challenges
+
+1. A clocking block appears to sample a signal one cycle late. What could cause this, and how would you fix it?
+2. During compilation, the same typedef appears to be defined twice. How can packages help resolve this conflict?


### PR DESCRIPTION
## Summary
- add industry and historical context plus career impact sections for RTL and testbench constructs
- expand expert insights with war stories, performance notes, and optimization tips
- include self-assessment exercises and debugging challenges

## Testing
- `npm test` *(fails: 19 failed)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68931ec87e14833097f32f4a263b1775