### PR TITLE
docs: expand RAL advanced topics

### DIFF
--- a/content/curriculum/T3_Advanced/A-UVM-4_The_UVM_Register_Abstraction_Layer_RAL/index.mdx
+++ b/content/curriculum/T3_Advanced/A-UVM-4_The_UVM_Register_Abstraction_Layer_RAL/index.mdx
@@ -135,6 +135,22 @@ RAL is not just for simulation. It can be a powerful bridge to formal verificati
 
 On a security-sensitive project, a key was stored in a register that was supposed to be write-only to prevent software from reading it out. The RAL model correctly marked it as "WO". However, a test was failing because a generic `uvm_reg_bit_bash_seq` was being run on the block. This built-in sequence performs both writes *and reads* to test every bit. The read operation on the write-only register was causing the DUT to fire a security violation interrupt, failing the test. **The lesson:** The built-in RAL sequences are powerful, but not "one size fits all." We had to create a custom `bit_bash_write_only_seq` that inherited from the base class but overrode the `do_read` task to be empty. This highlights the need to tailor even standard verification components to the specific requirements of your DUT.
 
+## Methodology Customization
+
+Even with auto-generated models, teams often need to refine how they use RAL. Customizing **register access policies** or extending built-in sequences allows engineers to match the verification methodology to project requirements. Examples include creating lightweight mirror sequences for rapid smoke tests or overriding default mirroring to support exotic design behavior.
+
+## Advanced Tool Integration
+
+Modern environments rarely exist in isolation. Integrating RAL with **specification management tools**, coverage dashboards, and formal apps can dramatically improve productivity. Many teams hook their RAL generation flow into IP-XACT or SystemRDL tooling so that a single update propagates through simulation, documentation, and formal property sets without manual edits.
+
+## Leadership & Strategy
+
+Large programs benefit from a coherent RAL strategy. Technical leaders set **coding guidelines**, maintain common RAL packages, and ensure cross-team training so that every block adopts a consistent model hierarchy. A shared approach reduces onboarding time and keeps verification teams focused on behavior rather than wrestling with incompatible register models.
+
+## Future Trends
+
+Expect RAL to evolve beyond scripted generation. Research groups are exploring **machine-learning–driven register modeling** that infers access patterns and anomalies from existing code or silicon data. Such tools could highlight undocumented fields, suggest optimal reset sequencing, or automatically detect mismatches between the spec and the implementation.
+
 ## Check Your Understanding
 
 <Quiz questions={[


### PR DESCRIPTION
## Summary
- expand Register Abstraction Layer (RAL) guide with methodology customization, tool integration, leadership strategy, and future trends

## Testing
- `npm test` (fails: Process from config.webServer exited early)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68931ecbe5348330846b521565adb6e6