### PR TITLE
docs: detail CodeReviewAssistant inputs

### DIFF
--- a/docs/components/CodeReviewAssistant.md
+++ b/docs/components/CodeReviewAssistant.md
@@ -13,6 +13,14 @@ Each automated check is implemented as a custom React hook that returns a `Check
 
 All hooks take no arguments and are purely illustrative; they would typically accept configuration or data about the commit under review.
 
+## Expected Inputs
+
+The review form collects three pieces of information from reviewers:
+
+- **Commit ID** – A SHA string (7–40 hexadecimal characters) identifying the commit under review.
+- **Comment** – Free‑form feedback text. Multiple comments can be submitted.
+- **Approval Toggle** – A boolean flag indicating whether the review has been approved.
+
 ## Peer‑Review Workflow
 
 1. **Commit ID** – Reviewers supply the hash of the commit being inspected.

--- a/src/components/ui/CodeReviewAssistant.tsx
+++ b/src/components/ui/CodeReviewAssistant.tsx
@@ -9,13 +9,8 @@ import { Textarea } from "./Textarea";
 import { useTimedCheck, CheckResult } from "./useTimedCheck";
 
 // ---------------------------------------------------------------------------
-// Hook and type definitions
+// Hook definitions
 // ---------------------------------------------------------------------------
-
-type CheckResult = {
-  status: "pending" | "pass" | "fail";
-  details?: string;
-};
 
 /**
  * Simulates a documentation completeness check for the current commit.
@@ -82,8 +77,13 @@ export const useCodingStandardsCheck = (): CheckResult => {
 // ---------------------------------------------------------------------------
 
 /**
- * Aggregates automated code quality checks and a minimal peer-review interface.
- * The component has no props and maintains its own state for comments and approval.
+ * Aggregates automated code quality checks—documentation, tests, architecture,
+ * and coding standards—with a minimal peer-review interface.
+ * Reviewers provide a commit SHA, free-form comments, and an approval toggle.
+ * Each verification uses custom hooks returning a `{status, details}` object.
+ *
+ * @example
+ * <CodeReviewAssistant /> // see `src/app/practice/interactive-demo/page.tsx`
  */
 export const CodeReviewAssistant = () => {
   // Automated check results


### PR DESCRIPTION
## Summary
- expand CodeReviewAssistant docs with expected inputs and usage link
- clean up component JSDoc and remove duplicate type definition

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test` *(fails: Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68931eebc8688330b478a44a26ba5f15