### PR TITLE
docs: expand advanced sequencing topics

### DIFF
--- a/content/curriculum/T3_Advanced/A-UVM-1_Advanced_Sequencing/index.mdx
+++ b/content/curriculum/T3_Advanced/A-UVM-1_Advanced_Sequencing/index.mdx
@@ -125,6 +125,32 @@ On a networking SoC, we had a test where a virtual sequence was supposed to send
 
 **The Outcome:** This architecture was incredibly robust and reusable. For a new test, an engineer simply had to write a new high-level sequence that combined the existing mid-level and low-level blocks. Debugging was also simplified; if a TLP was malformed, the bug was in the TLP sequence layer. If TLPs were dropped, the bug was in the flow control layer. This separation of concerns is the hallmark of a well-architected sequencing strategy.
 
+## Level 5: Strategic Integration & Future Trends
+
+### Performance Optimization
+
+Efficient sequences preserve **simulation speed** and manage *memory use* by minimizing redundant object creation, reusing `uvm_sequence_item` instances, and carefully tuning `uvm_phase` synchronization.
+
+### SoC-Level Sequencing Strategies
+
+At the SoC level, a **system-level virtual sequence** can coordinate multiple sub-systems by monitoring global events, using cross-sequencer handshakes, and enforcing top-level *power and reset* policies.
+
+### Formal Verification Integration
+
+Advanced flows combine UVM sequences with **formal verification** by replaying formally generated traces, constraining sequence randomization, and exporting **assumptions** for formal tools.
+
+### Methodology Customization Tips
+
+Teams often extend `uvm_sequence` with project-specific base classes, custom **factory overrides**, and tailored *sequence item* allocation policies to match their methodology.
+
+### Advanced Tool Integration
+
+Hook sequences into **CI** pipelines and regression dashboards by parameterizing seeds, reporting coverage, and leveraging build artifacts for automated *failure triage*.
+
+### Leadership and Cutting-Edge Topics
+
+Forward-looking teams experiment with **machine learning** to guide sequence generation and use cloud-based farms for scalable *virtual sequencer* execution.
+
 ## Check Your Understanding
 
 <Quiz questions={[


### PR DESCRIPTION
## Summary
- add "Level 5" section to advanced sequencing curriculum
- cover performance tuning, SoC strategies, formal integration, methodology customization, tool integration, and leadership/ML topics

## Testing
- `npm test` (fails: tests/e2e/*, navigation, theming, etc.)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68931f92b2dc833085a8c29472695d51