### PR TITLE
test: import within helper

### DIFF
--- a/tests/components/CodeReviewAssistant.test.tsx
+++ b/tests/components/CodeReviewAssistant.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi } from 'vitest';
 import CodeReviewAssistant from '../../src/components/ui/CodeReviewAssistant';


### PR DESCRIPTION
## Summary
- import the `within` helper from `@testing-library/react` in `CodeReviewAssistant` tests

## Testing
- `npm test` *(fails: 19 tests failed)*
- `npx vitest run tests/components/CodeReviewAssistant.test.tsx` *(fails: 1 test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68932cc93b1c83308cb714a5081714b3