### PR TITLE
Add real-world case study for UVM factory overrides

### DIFF
--- a/content/curriculum/T3_Advanced/A-UVM-2_The_UVM_Factory_In-Depth/index.mdx
+++ b/content/curriculum/T3_Advanced/A-UVM-2_The_UVM_Factory_In-Depth/index.mdx
@@ -82,6 +82,30 @@ As a verification lead or architect, how you manage the factory is a critical po
 
 - **Policy on String-Based Overrides:** Do you allow them? A good policy is to **ban string-based overrides in all RTL-level testbenches**. They are acceptable for scripting or top-level testbenches where flexibility is key, but for reusable VIP, the compile-time safety of `get_type()` overrides is essential.
 
+### Real-World Case Study
+
+During verification of a multi-port Ethernet switch, the team needed to inject malformed packets on only one port while the other ports used the standard driver. The original environment created the default driver for every port agent:
+
+<InteractiveCode>
+```systemverilog
+// build_phase before override
+m_port_driver = eth_driver::type_id::create("m_port_driver", this);
+```
+</InteractiveCode>
+
+Instead of modifying the reusable agent, the test applied an instance override to swap in a fault-injecting driver solely for the stressed port:
+
+<InteractiveCode>
+```systemverilog
+// In the test's build_phase
+factory.set_inst_override_by_type("env.port3.m_port_driver",
+                                  eth_driver::get_type(),
+                                  eth_err_driver::get_type());
+```
+</InteractiveCode>
+
+**Lessons Learned:** Centralizing overrides in the test kept the agent reusable and prevented accidental propagation of the error driver. Using `get_type()` avoided the string typos that previously caused silent misconfigurations.
+
 ## Level 4: Architect's Corner
 
 ### Advanced Factory Usage: The "Abstract Agent" Pattern


### PR DESCRIPTION
## Summary
- add a real-world case study section illustrating factory overrides
- show before/after code snippets for targeted driver replacement

## Testing
- `npm test` (fails: 18 failed)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68932d7007108330a9cc1bb98770412a