### PR TITLE
feat: expand methodology customization

### DIFF
--- a/content/curriculum/T4_Expert/E-CUST-1_UVM_Methodology_Customization/index.mdx
+++ b/content/curriculum/T4_Expert/E-CUST-1_UVM_Methodology_Customization/index.mdx
@@ -124,8 +124,97 @@ Your UVM methodology is a software project and should be treated as such.
 - **Performance Optimization:** Profile critical components and provide configuration switches for lightweight "fast" modes that keep regressions running efficiently.
 - **Debug Methodology:** Standardize logging, waveform bookmarks, and failure triage APIs so engineers can diagnose issues quickly across projects.
 - **SoC-Level Verification:** Support hierarchical configuration, multi-IP coordination, and top-level scoreboards required for complex SoC environments.
-- **Formal Integration:** Offer bridges to assertion libraries and formal apps so the same methodology spans simulation and formal verification flows.
-- **Cutting Edge (ML & Cloud):** Experiment with machine-learning to prioritize regressions and analyze results, and package your environment for cloud-based regression farms.
+
+### Formal Verification Integration
+
+Bridging simulation and formal flows lets teams reuse properties and close coverage more efficiently.
+
+<InteractiveCode
+  language="systemverilog"
+  fileName="reusable_property.sv"
+  code={`
+// 1. Define the property once in a package
+package arb_props;
+  property req_gnt;
+    @(posedge clk) req |-> ##[1:2] gnt;
+  endproperty
+endpackage
+
+// 2. Bind the property into the design
+bind arbiter arb_props req_gnt_assert: assert property(arb_props::req_gnt);
+
+// 3. Cover to track closure in both sim and formal
+cover property (@(posedge clk) req ##1 gnt);
+  `}
+  explanationSteps={[
+    { target: "2-6", title: "Reusable Property", explanation: "Package the property so the same definition is shared across simulation and formal runs." },
+    { target: "8-9", title: "Binding", explanation: "Bind the property to the DUT to avoid modifying RTL." },
+    { target: "11-11", title: "Coverage Closure", explanation: "Cover directives help determine when the property has been exercised." }
+  ]}
+/>
+
+**Best Practices Checklist**
+
+- [ ] Collect assertions in shared packages for reuse.
+- [ ] Track both assertion and cover property metrics to drive coverage closure.
+- [ ] Use `bind` so RTL remains untouched.
+
+### Leadership & Strategy for Methodology Rollout
+
+Rolling out a custom methodology across teams requires planning, tooling, and clear ownership.
+
+<InteractiveCode
+  language="bash"
+  fileName="rollout.sh"
+  code={`#!/usr/bin/env bash
+set -e
+git clone https://git.example.com/uvm_methodology.git
+cd uvm_methodology
+npm ci
+./install_hooks.sh ../my_project
+  `}
+  explanationSteps={[
+    { target: "1-6", title: "Bootstrap Script", explanation: "Automates fetching the methodology repository and installing standard hooks into a new project." }
+  ]}
+/>
+
+**Best Practices Checklist**
+
+- [ ] Nominate a methodology owner or steering committee.
+- [ ] Pilot the flow on a small project before organization-wide rollout.
+- [ ] Provide versioned documentation and regular training sessions.
+
+### Cutting-Edge Topics: Cloud & ML Customization
+
+Emerging trends like cloud-based regression farms and ML-driven configuration can further optimize verification.
+
+<InteractiveCode
+  language="python"
+  fileName="ml_config.py"
+  code={`import requests
+import yaml
+from sklearn.ensemble import RandomForestClassifier
+
+def choose_seed(history):
+  model = RandomForestClassifier().fit(history['features'], history['labels'])
+  return int(model.predict([history['current']])[0])
+
+cfg = requests.get("https://config.example.com/myproj").json()
+cfg['seed'] = choose_seed(cfg['history'])
+print(yaml.dump(cfg))
+  `}
+  explanationSteps={[
+    { target: "1-3", title: "Cloud & ML Imports", explanation: "Pull configuration from a cloud service and use an ML model to predict parameters." },
+    { target: "5-7", title: "Model Training", explanation: "Train a simple classifier on past regression data." },
+    { target: "9-10", title: "ML-Assisted Config", explanation: "Update the configuration with an ML-selected random seed." }
+  ]}
+/>
+
+**Best Practices Checklist**
+
+- [ ] Externalize configuration so cloud jobs can override parameters easily.
+- [ ] Use ML models to prioritize tests or tune random seeds based on history.
+- [ ] Monitor resource usage and costs in cloud environments.
 
 ## Level 4: Architect's Corner
 


### PR DESCRIPTION
## Summary
- expand methodology guide with formal verification integration, leadership strategy, and cutting-edge ML/cloud sections
- add code examples and best-practice checklists for new topics

## Testing
- `npm test` *(fails: tests/e2e/curriculum-integrity.spec.ts, tests/e2e/curriculum-links.spec.ts, tests/e2e/curriculum-nav.spec.ts, tests/e2e/interactive-demo.spec.ts, tests/e2e/labs.spec.ts, tests/e2e/mobile-navigation.spec.ts, tests/e2e/module5.spec.ts, tests/e2e/navigation.spec.ts, tests/e2e/simple-test.spec.ts, tests/e2e/theming.spec.ts)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68932d724e38833091552ca983600721