### PR TITLE
feat: add commit review API

### DIFF
--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server';
+
+interface Review {
+  commitId: string;
+  comment?: string;
+  approved?: boolean;
+}
+
+const reviews: Review[] = [];
+
+export function getReviews() {
+  return reviews;
+}
+
+export async function POST(request: Request) {
+  let data: any;
+  try {
+    data = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const { commitId, comment, approved } = data ?? {};
+  if (!commitId || typeof commitId !== 'string') {
+    return NextResponse.json({ error: 'commitId is required' }, { status: 400 });
+  }
+  const shaRegex = /^[0-9a-f]{7,40}$/i;
+  if (!shaRegex.test(commitId)) {
+    return NextResponse.json({ error: 'Invalid commitId' }, { status: 400 });
+  }
+
+  const record: Review = { commitId };
+  if (typeof comment === 'string') {
+    record.comment = comment;
+  }
+  if (typeof approved === 'boolean') {
+    record.approved = approved;
+  }
+  reviews.push(record);
+  return NextResponse.json({ message: 'Review recorded' }, { status: 201 });
+}

--- a/tests/api/reviews.test.ts
+++ b/tests/api/reviews.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { POST, getReviews } from '../../src/app/api/reviews/route';
+
+function makeRequest(body: any) {
+  return new Request('http://localhost/api/reviews', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/reviews', () => {
+  it('stores reviews and returns 201', async () => {
+    const res = await POST(makeRequest({ commitId: 'abcdef1', comment: 'good' }));
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json).toEqual({ message: 'Review recorded' });
+    expect(getReviews()).toContainEqual({ commitId: 'abcdef1', comment: 'good' });
+  });
+
+  it('rejects requests without commitId', async () => {
+    const res = await POST(makeRequest({ comment: 'bad' }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/components/CodeReviewAssistant.test.tsx
+++ b/tests/components/CodeReviewAssistant.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi } from 'vitest';
 import CodeReviewAssistant from '../../src/components/ui/CodeReviewAssistant';
@@ -31,15 +31,12 @@ describe('CodeReviewAssistant component', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     render(<CodeReviewAssistant />);
-    const commitInput = screen.getByPlaceholderText(/commit id/i);
-    await userEvent.type(commitInput, 'abc1234');
-
     const input = screen.getByPlaceholderText(/commit id/i);
+    await userEvent.type(input, 'abcdef1');
 
     const textarea = screen.getByPlaceholderText(/leave a comment/i);
     const addButton = screen.getByRole('button', { name: /add comment/i });
 
-    await userEvent.type(input, 'abcdef1');
     await userEvent.type(textarea, '  first comment  ');
     await userEvent.click(addButton);
     await screen.findByText('first comment');


### PR DESCRIPTION
## Summary
- add `/api/reviews` route to accept commit review payloads
- cover review endpoint with unit tests
- fix CodeReviewAssistant tests

## Testing
- `npx vitest tests/api/reviews.test.ts tests/components/CodeReviewAssistant.test.tsx tests/quiz.spec.tsx tests/srs.spec.ts --run`
- `npm test` *(fails: e2e playwright tests)*

------
https://chatgpt.com/codex/tasks/task_e_68932e11520083308a449fb2cc15bcc9