### PR TITLE
feat: add reviews API route

### DIFF
--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { addReview, Review } from '@/server/reviews';
+
+export async function POST(request: Request) {
+  let body: Partial<Review>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const { commitId, comment, approved } = body;
+  if (!commitId || typeof commitId !== 'string') {
+    return NextResponse.json({ error: 'commitId is required' }, { status: 400 });
+  }
+
+  addReview({ commitId, comment, approved });
+  return NextResponse.json({ message: 'Review stored' }, { status: 201 });
+}

--- a/src/server/reviews.ts
+++ b/src/server/reviews.ts
@@ -1,0 +1,19 @@
+export interface Review {
+  commitId: string;
+  comment?: string;
+  approved?: boolean;
+}
+
+const reviews: Review[] = [];
+
+export function addReview(review: Review) {
+  reviews.push(review);
+}
+
+export function getReviews() {
+  return reviews;
+}
+
+export function clearReviews() {
+  reviews.length = 0;
+}

--- a/tests/reviews.spec.ts
+++ b/tests/reviews.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { POST } from '@/app/api/reviews/route';
+import { getReviews, clearReviews } from '@/server/reviews';
+
+function createRequest(body: any) {
+  return new Request('http://localhost/api/reviews', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('Reviews API', () => {
+  beforeEach(() => {
+    clearReviews();
+  });
+
+  it('stores review successfully', async () => {
+    const req = createRequest({ commitId: 'abc123', comment: 'Looks good', approved: true });
+    const res = await POST(req);
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data).toEqual({ message: 'Review stored' });
+    expect(getReviews()).toContainEqual({ commitId: 'abc123', comment: 'Looks good', approved: true });
+  });
+
+  it('returns 400 when commitId is missing', async () => {
+    const req = createRequest({ comment: 'Missing commitId' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add POST /api/reviews route that stores commit reviews
- keep simple in-memory review store
- add tests for review API success and missing commitId cases

## Testing
- `npx vitest run tests/reviews.spec.ts tests/srs.spec.ts tests/quiz.spec.tsx`
- `npm test tests/e2e/simple-test.spec.ts` (fails: browser executable doesn't exist)
- `npm run type-check` (fails: tests/components/CodeReviewAssistant.test.tsx cannot find name 'within')

------
https://chatgpt.com/codex/tasks/task_e_68932dd3a3ec8330be368837052dc67c