### PR TITLE
feat: enhance diagrams and animations

### DIFF
--- a/src/components/animations/SystemVerilogDataTypesAnimation.tsx
+++ b/src/components/animations/SystemVerilogDataTypesAnimation.tsx
@@ -23,11 +23,22 @@ const SystemVerilogDataTypesAnimation = () => {
   const [fourStateValue, setFourStateValue] = useState<StateColorKey>('0');
   const [packedDim, setPackedDim] = useState(4);
   const [unpackedDim, setUnpackedDim] = useState(3);
+  const [inputA, setInputA] = useState<StateColorKey>('0');
+  const [inputB, setInputB] = useState<StateColorKey>('0');
+  const [dynArray, setDynArray] = useState<number[]>([]);
 
   const cycleState = (currentValue: StateColorKey, values: StateColorKey[]) => {
     const currentIndex = values.indexOf(currentValue);
     return values[(currentIndex + 1) % values.length];
   };
+
+  const computeAnd = (a: StateColorKey, b: StateColorKey): StateColorKey => {
+    if (a === '0' || b === '0') return '0';
+    if (a === '1' && b === '1') return '1';
+    return 'X';
+  };
+
+  const andOutput = computeAnd(inputA, inputB);
 
   return (
     <Card className="w-full">
@@ -79,6 +90,43 @@ const SystemVerilogDataTypesAnimation = () => {
 
         <hr className="my-8" />
 
+        {/* X/Z Propagation */}
+        <div className="mb-8">
+          <h3 className="text-lg font-bold mb-2">X/Z Propagation (AND Gate)</h3>
+          <div className="flex items-center gap-4 mb-2">
+            <motion.div
+              key={inputA}
+              className={`w-14 h-14 flex items-center justify-center text-white font-bold rounded-lg ${stateColor[inputA]}`}
+              initial={{ scale: 0.5, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+            >
+              {inputA}
+            </motion.div>
+            <span className="font-mono">AND</span>
+            <motion.div
+              key={inputB}
+              className={`w-14 h-14 flex items-center justify-center text-white font-bold rounded-lg ${stateColor[inputB]}`}
+              initial={{ scale: 0.5, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+            >
+              {inputB}
+            </motion.div>
+            <span className="font-mono">=</span>
+            <motion.div
+              key={andOutput}
+              className={`w-14 h-14 flex items-center justify-center text-white font-bold rounded-lg ${stateColor[andOutput]}`}
+              initial={{ scale: 0.5, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+            >
+              {andOutput}
+            </motion.div>
+          </div>
+          <div className="flex gap-2">
+            <Button size="sm" onClick={() => setInputA(cycleState(inputA, FourStateValues))}>A</Button>
+            <Button size="sm" onClick={() => setInputB(cycleState(inputB, FourStateValues))}>B</Button>
+          </div>
+        </div>
+
         {/* Array Visualization */}
         <div>
           <h3 className="text-lg font-bold mb-4">Packed vs. Unpacked Arrays</h3>
@@ -127,6 +175,29 @@ const SystemVerilogDataTypesAnimation = () => {
                 ))}
               </div>
             </div>
+          </div>
+        </div>
+
+        <hr className="my-8" />
+
+        {/* Dynamic Array Operations */}
+        <div>
+          <h3 className="text-lg font-bold mb-2">Dynamic Array Operations</h3>
+          <div className="flex gap-2 mb-2">
+            <Button size="sm" onClick={() => setDynArray(prev => [...prev, Math.floor(Math.random() * 10)])}>Push</Button>
+            <Button size="sm" onClick={() => setDynArray(prev => prev.slice(0, -1))} disabled={dynArray.length === 0}>Pop</Button>
+          </div>
+          <div className="flex gap-1">
+            {dynArray.map((v, i) => (
+              <motion.div
+                key={i}
+                className="w-8 h-8 bg-purple-200 border border-purple-400 flex items-center justify-center text-xs"
+                initial={{ scale: 0 }}
+                animate={{ scale: 1 }}
+              >
+                {v}
+              </motion.div>
+            ))}
           </div>
         </div>
       </CardContent>

--- a/src/components/diagrams/UvmPhasingInteractiveTimeline.tsx
+++ b/src/components/diagrams/UvmPhasingInteractiveTimeline.tsx
@@ -48,7 +48,13 @@ const UvmPhasingInteractiveTimeline = () => {
           >
             <h3 className="text-lg font-bold text-primary">{currentPhase.name}</h3>
             <p className="text-sm text-muted-foreground mb-2">Type: {currentPhase.type} | {currentPhase.isTask ? 'Task' : 'Function'}</p>
-            <p>{currentPhase.description}</p>
+            <p className="mb-2">{currentPhase.description}</p>
+            {currentPhase.dependencies && (
+              <p className="text-sm mb-1">Depends on: {currentPhase.dependencies.join(', ')}</p>
+            )}
+            {currentPhase.objection && (
+              <p className="text-sm text-muted-foreground">Objections: {currentPhase.objection}</p>
+            )}
           </motion.div>
         </AnimatePresence>
 

--- a/src/components/diagrams/uvm-phasing-data.ts
+++ b/src/components/diagrams/uvm-phasing-data.ts
@@ -3,32 +3,34 @@ export interface UvmPhase {
   type: 'build' | 'connect' | 'run' | 'cleanup';
   description: string;
   isTask: boolean;
+  dependencies?: string[];
+  objection?: string;
 }
 
 export const uvmPhases: UvmPhase[] = [
   // Build Phases (run in order, top-down)
   { name: 'build', type: 'build', description: 'Constructs component hierarchy. New components are created here.', isTask: false },
-  { name: 'connect', type: 'connect', description: 'Connects TLM ports and exports. Establishes communication paths.', isTask: false },
-  { name: 'end_of_elaboration', type: 'connect', description: 'Final checks before simulation starts. Final adjustments to component settings.', isTask: false },
+  { name: 'connect', type: 'connect', description: 'Connects TLM ports and exports. Establishes communication paths.', isTask: false, dependencies: ['build'] },
+  { name: 'end_of_elaboration', type: 'connect', description: 'Final checks before simulation starts. Final adjustments to component settings.', isTask: false, dependencies: ['connect'] },
 
   // Run-Time Phases (run in parallel)
-  { name: 'start_of_simulation', type: 'run', description: 'Prepare for the main simulation. Display banners, set up initial state.', isTask: false },
-  { name: 'pre_reset', type: 'run', description: 'Tasks before reset is asserted. E.g., wait for power-on.', isTask: true },
-  { name: 'reset', type: 'run', description: 'Assert and de-assert reset signals.', isTask: true },
-  { name: 'post_reset', type: 'run', description: 'Tasks after reset is de-asserted. E.g., configure DUT.', isTask: true },
-  { name: 'pre_configure', type: 'run', description: 'Prepare for main stimulus. E.g., load memories.', isTask: true },
-  { name: 'configure', type: 'run', description: 'Apply configuration to the DUT.', isTask: true },
-  { name: 'post_configure', type: 'run', description: 'Wait for configuration to take effect.', isTask: true },
-  { name: 'pre_main', type: 'run', description: 'Final preparations before the main stimulus.', isTask: true },
-  { name: 'main', type: 'run', description: 'The main stimulus generation and checking phase.', isTask: true },
-  { name: 'post_main', type: 'run', description: 'Stimulus is complete, wait for DUT to settle.', isTask: true },
-  { name: 'pre_shutdown', type: 'run', description: 'Prepare for the end of the test.', isTask: true },
-  { name: 'shutdown', type: 'run', description: 'Final stimulus, e.g., read out status registers.', isTask: true },
-  { name: 'post_shutdown', type: 'run', description: 'Wait for all shutdown activity to complete.', isTask: true },
+  { name: 'start_of_simulation', type: 'run', description: 'Prepare for the main simulation. Display banners, set up initial state.', isTask: false, dependencies: ['end_of_elaboration'] },
+  { name: 'pre_reset', type: 'run', description: 'Tasks before reset is asserted. E.g., wait for power-on.', isTask: true, dependencies: ['start_of_simulation'] },
+  { name: 'reset', type: 'run', description: 'Assert and de-assert reset signals.', isTask: true, dependencies: ['pre_reset'] },
+  { name: 'post_reset', type: 'run', description: 'Tasks after reset is de-asserted. E.g., configure DUT.', isTask: true, dependencies: ['reset'] },
+  { name: 'pre_configure', type: 'run', description: 'Prepare for main stimulus. E.g., load memories.', isTask: true, dependencies: ['post_reset'] },
+  { name: 'configure', type: 'run', description: 'Apply configuration to the DUT.', isTask: true, dependencies: ['pre_configure'] },
+  { name: 'post_configure', type: 'run', description: 'Wait for configuration to take effect.', isTask: true, dependencies: ['configure'] },
+  { name: 'pre_main', type: 'run', description: 'Final preparations before the main stimulus.', isTask: true, dependencies: ['post_configure'] },
+  { name: 'main', type: 'run', description: 'The main stimulus generation and checking phase.', isTask: true, dependencies: ['pre_main'], objection: 'Raise and drop objections to control test completion.' },
+  { name: 'post_main', type: 'run', description: 'Stimulus is complete, wait for DUT to settle.', isTask: true, dependencies: ['main'] },
+  { name: 'pre_shutdown', type: 'run', description: 'Prepare for the end of the test.', isTask: true, dependencies: ['post_main'] },
+  { name: 'shutdown', type: 'run', description: 'Final stimulus, e.g., read out status registers.', isTask: true, dependencies: ['pre_shutdown'], objection: 'Drop objections once shutdown tasks finish.' },
+  { name: 'post_shutdown', type: 'run', description: 'Wait for all shutdown activity to complete.', isTask: true, dependencies: ['shutdown'] },
 
   // Cleanup Phases (run in order, bottom-up)
-  { name: 'extract', type: 'cleanup', description: 'Extract data from scoreboard and coverage collectors.', isTask: false },
-  { name: 'check', type: 'cleanup', description: 'Check for simulation errors and report results.', isTask: false },
-  { name: 'report', type: 'cleanup', description: 'Generate final simulation report.', isTask: false },
-  { name: 'final', type: 'cleanup', description: 'Final cleanup before simulation terminates.', isTask: false },
+  { name: 'extract', type: 'cleanup', description: 'Extract data from scoreboard and coverage collectors.', isTask: false, dependencies: ['post_shutdown'] },
+  { name: 'check', type: 'cleanup', description: 'Check for simulation errors and report results.', isTask: false, dependencies: ['extract'] },
+  { name: 'report', type: 'cleanup', description: 'Generate final simulation report.', isTask: false, dependencies: ['check'] },
+  { name: 'final', type: 'cleanup', description: 'Final cleanup before simulation terminates.', isTask: false, dependencies: ['report'] },
 ];


### PR DESCRIPTION
## Summary
- add export, search zoom, and flow toggles to UVM architecture diagram
- highlight selected nodes and show relationship stats in relationship visualizer
- expand phasing timeline with dependencies and objection info
- illustrate X/Z propagation and dynamic array operations for SV data types

## Testing
- `npm test` *(fails: 19 failed)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68933710e9bc8330a823e63324a4b85a