### PR TITLE
feat: add procedural block animations

### DIFF
--- a/src/components/animations/ProceduralBlocksSimulator.tsx
+++ b/src/components/animations/ProceduralBlocksSimulator.tsx
@@ -1,11 +1,138 @@
 "use client";
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { proceduralBlocksData } from './procedural-blocks-data';
 import { Button } from '@/components/ui/Button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
 import { CodeBlock } from '@/components/ui/CodeBlock';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/Select';
+
+// Waveform data for blocking vs non-blocking assignments
+const waveformData = {
+  blocking: [
+    { time: 0, a: 1, b: 2 },
+    { time: 1, a: 2, b: 2 },
+    { time: 2, a: 2, b: 2 },
+  ],
+  nonBlocking: [
+    { time: 0, a: 1, b: 2 },
+    { time: 1, a: 1, b: 2 },
+    { time: 2, a: 2, b: 1 },
+  ],
+};
+
+const Waveform: React.FC<{ data: { time: number; a: number; b: number }[] }> = ({ data }) => {
+  const width = 200;
+  const height = 60;
+  const step = width / (data.length - 1);
+  const scaleY = (v: number) => height - v * 20;
+
+  const buildPath = (key: 'a' | 'b') => {
+    let d = `M 0 ${scaleY(data[0][key])}`;
+    for (let i = 1; i < data.length; i++) {
+      const x = i * step;
+      d += ` H ${x} V ${scaleY(data[i][key])}`;
+    }
+    return d;
+  };
+
+  const pathA = buildPath('a');
+  const pathB = buildPath('b');
+
+  return (
+    <svg width={width} height={height} className="bg-background rounded">
+      <motion.path
+        d={pathA}
+        fill="none"
+        stroke="#ef4444"
+        strokeWidth={2}
+        initial={{ pathLength: 0 }}
+        animate={{ pathLength: 1 }}
+        transition={{ duration: 1 }}
+      />
+      <motion.path
+        d={pathB}
+        fill="none"
+        stroke="#3b82f6"
+        strokeWidth={2}
+        initial={{ pathLength: 0 }}
+        animate={{ pathLength: 1 }}
+        transition={{ duration: 1, delay: 0.2 }}
+      />
+    </svg>
+  );
+};
+
+const BlockingNonBlockingTimeline = () => (
+  <div className="grid md:grid-cols-2 gap-4 mt-4">
+    <div className="flex flex-col items-center">
+      <h4 className="mb-2">Blocking</h4>
+      <Waveform data={waveformData.blocking} />
+    </div>
+    <div className="flex flex-col items-center">
+      <h4 className="mb-2">Non-blocking</h4>
+      <Waveform data={waveformData.nonBlocking} />
+    </div>
+  </div>
+);
+
+const ForkJoinAnimation = () => (
+  <div className="relative w-full h-24 bg-muted rounded mt-4 overflow-hidden">
+    <motion.div
+      className="absolute top-2 left-0 h-6 bg-primary"
+      initial={{ width: 0 }}
+      animate={{ width: '100%' }}
+      transition={{ duration: 2 }}
+    />
+    <motion.div
+      className="absolute top-14 left-0 h-6 bg-secondary"
+      initial={{ width: 0 }}
+      animate={{ width: '100%' }}
+      transition={{ duration: 4 }}
+    />
+    <motion.div
+      className="absolute bottom-0 left-0 right-0 h-2 bg-accent"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ delay: 4 }}
+    />
+  </div>
+);
+
+const EventWaitAnimation = () => {
+  const [clk, setClk] = useState(false);
+
+  useEffect(() => {
+    const id = setInterval(() => setClk(c => !c), 800);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div className="flex items-center space-x-4 mt-4">
+      <div className="flex items-center space-x-2">
+        <span>clk</span>
+        <motion.div
+          className="w-4 h-4 rounded-full"
+          animate={{ backgroundColor: clk ? '#22c55e' : '#6b7280' }}
+          transition={{ duration: 0.2 }}
+        />
+      </div>
+      <AnimatePresence>
+        {clk && (
+          <motion.div
+            key="proc"
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 10 }}
+            className="px-2 py-1 bg-primary text-primary-foreground rounded"
+          >
+            Triggered
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+};
 
 const ProceduralBlocksSimulator = () => {
   const [exampleIndex, setExampleIndex] = useState(0);
@@ -27,6 +154,19 @@ const ProceduralBlocksSimulator = () => {
   const currentExample = proceduralBlocksData[exampleIndex];
   const currentStep = currentExample.steps[currentStepIndex];
 
+  const renderVisualization = () => {
+    switch (currentExample.name) {
+      case 'Blocking vs. Non-blocking':
+        return <BlockingNonBlockingTimeline />;
+      case 'Fork/Join':
+        return <ForkJoinAnimation />;
+      case 'Always Block':
+        return <EventWaitAnimation />;
+      default:
+        return null;
+    }
+  };
+
   return (
     <Card className="w-full">
       <CardHeader>
@@ -45,6 +185,8 @@ const ProceduralBlocksSimulator = () => {
         </Select>
 
         <CodeBlock code={currentExample.code} language="systemverilog" />
+
+        {renderVisualization()}
 
         <AnimatePresence mode="wait">
           <motion.div

--- a/src/components/animations/procedural-blocks-data.ts
+++ b/src/components/animations/procedural-blocks-data.ts
@@ -34,4 +34,14 @@ export const proceduralBlocksData: ProceduralBlockExample[] = [
       'The second always block uses non-blocking assignments (`<=`). The assignments are scheduled to happen at the end of the time step. `a` and `b` are swapped correctly.',
     ],
   },
+  {
+    name: 'Fork/Join',
+    code: 'initial begin\n  fork\n    #5 a = 1;\n    #10 b = 2;\n  join\nend',
+    steps: [
+      'Two parallel threads are launched with `fork`.',
+      'Thread 1 waits 5 time units then assigns `a`.',
+      'Thread 2 waits 10 time units then assigns `b`.',
+      'The `join` waits for both threads to complete before continuing.',
+    ],
+  },
 ];


### PR DESCRIPTION
## Summary
- visualize blocking vs non-blocking assignments with waveform timeline
- animate fork/join threads and event-trigger waits
- document new fork/join procedural block example

## Testing
- `npm test` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/...)*

------
https://chatgpt.com/codex/tasks/task_e_689439592c4883308842ed95e4b14558