### PR TITLE
feat: enhance state machine designer

### DIFF
--- a/src/components/animations/StateMachineDesigner.tsx
+++ b/src/components/animations/StateMachineDesigner.tsx
@@ -13,10 +13,16 @@ const DraggableState = ({
   id,
   state,
   onRemove,
+  onClick,
+  selected,
+  encodingValue,
 }: {
   id: string;
   state: State;
   onRemove: (id: string) => void;
+  onClick: (id: string) => void;
+  selected: boolean;
+  encodingValue: string;
 }) => {
   const { attributes, listeners, setNodeRef, transform } = useDraggable({ id });
   const style = transform
@@ -31,9 +37,15 @@ const DraggableState = ({
       style={{ ...style, position: 'absolute', left: state.x, top: state.y }}
       {...listeners}
       {...attributes}
+      onClick={() => onClick(id)}
     >
-      <div className="relative w-24 h-16 bg-primary text-primary-foreground rounded-lg flex items-center justify-center cursor-grab">
-        {state.name}
+      <div
+        className={`relative w-24 h-16 rounded-lg flex items-center justify-center cursor-grab bg-primary text-primary-foreground ${selected ? 'ring-2 ring-secondary' : ''}`}
+      >
+        <div className="flex flex-col items-center">
+          <span>{state.name}</span>
+          <span className="text-xs">{encodingValue}</span>
+        </div>
         <button
           className="absolute -top-2 -right-2 w-5 h-5 bg-destructive text-destructive-foreground rounded-full flex items-center justify-center text-xs"
           onMouseDown={(e) => e.stopPropagation()}
@@ -58,6 +70,16 @@ const StateMachineDesigner = () => {
     source: '',
     target: '',
   });
+  const [pendingTransition, setPendingTransition] = useState<string | null>(null);
+  const [analysis, setAnalysis] = useState<{
+    unreachable: string[];
+    dead: Transition[];
+  }>({ unreachable: [], dead: [] });
+  const [currentState, setCurrentState] = useState<string | null>(
+    stateMachineData[0].states[0]?.id || null
+  );
+  const [visitedStates, setVisitedStates] = useState<Set<string>>(new Set());
+  const [visitedTransitions, setVisitedTransitions] = useState<Set<number>>(new Set());
   const stateCounter = useRef(states.length + 1);
   const svgRef = useRef<SVGSVGElement>(null);
 
@@ -83,6 +105,46 @@ const StateMachineDesigner = () => {
     setTransitions((t) => t.filter((_, i) => i !== index));
   };
 
+  const handleStateClick = (id: string) => {
+    setPendingTransition((prev) => {
+      if (!prev) return id;
+      if (prev !== id) {
+        setTransitions((t) => [...t, { source: prev, target: id }]);
+      }
+      return null;
+    });
+  };
+
+  const encodeState = (index: number) => {
+    if (encoding === 'onehot') {
+      return states.map((_, i) => (i === index ? '1' : '0')).join('');
+    }
+    const width = Math.max(1, Math.ceil(Math.log2(states.length)));
+    let value = index;
+    if (encoding === 'gray') {
+      value = index ^ (index >> 1);
+    }
+    return value.toString(2).padStart(width, '0');
+  };
+
+  const runStep = () => {
+    if (!currentState) return;
+    setVisitedStates((s) => new Set(s).add(currentState));
+    const options = transitions
+      .map((t, i) => ({ ...t, i }))
+      .filter((t) => t.source === currentState);
+    if (options.length === 0) return;
+    const choice = options[Math.floor(Math.random() * options.length)];
+    setVisitedTransitions((s) => new Set(s).add(choice.i));
+    setCurrentState(choice.target);
+  };
+
+  const resetSimulation = React.useCallback(() => {
+    setVisitedStates(new Set());
+    setVisitedTransitions(new Set());
+    setCurrentState(states[0]?.id || null);
+  }, [states]);
+
   const toggleMode = () => setMode((m) => (m === 'Moore' ? 'Mealy' : 'Moore'));
 
   const handleDragEnd = (event: any) => {
@@ -105,7 +167,7 @@ const StateMachineDesigner = () => {
 
     svg
       .selectAll('path')
-      .data(transitions)
+      .data(transitions.map((t, i) => ({ ...t, i })))
       .enter()
       .append('path')
       .attr('d', (d) => {
@@ -119,8 +181,36 @@ const StateMachineDesigner = () => {
       })
       .attr('stroke', 'hsl(var(--primary))')
       .attr('stroke-width', 2)
-      .attr('fill', 'none');
+      .attr('fill', 'none')
+      .style('cursor', 'pointer')
+      .on('click', (_, d) => removeTransition(d.i));
   }, [states, transitions]);
+
+  useEffect(() => {
+    // analysis for unreachable states and dead transitions
+    const reachable = new Set<string>();
+    const start = states[0]?.id;
+    if (start) {
+      const stack = [start];
+      while (stack.length) {
+        const id = stack.pop();
+        if (!id || reachable.has(id)) continue;
+        reachable.add(id);
+        transitions
+          .filter((t) => t.source === id)
+          .forEach((t) => stack.push(t.target));
+      }
+    }
+    const unreachable = states
+      .filter((s) => !reachable.has(s.id))
+      .map((s) => s.name);
+    const dead = transitions.filter((t) => !reachable.has(t.source));
+    setAnalysis({ unreachable, dead });
+  }, [states, transitions]);
+
+  useEffect(() => {
+    resetSimulation();
+  }, [states, transitions, resetSimulation]);
 
   return (
     <DndContext onDragEnd={handleDragEnd}>
@@ -237,17 +327,54 @@ const StateMachineDesigner = () => {
 
             <div className="text-sm">
               <p>Coverage Metrics:</p>
-              <p>States: {states.length}</p>
-              <p>Transitions: {transitions.length}</p>
+              <p>
+                States: {visitedStates.size}/{states.length}
+              </p>
+              <p>
+                Transitions: {visitedTransitions.size}/{transitions.length}
+              </p>
+            </div>
+
+            {(analysis.unreachable.length > 0 || analysis.dead.length > 0) && (
+              <div className="text-sm text-yellow-700">
+                {analysis.unreachable.length > 0 && (
+                  <p>
+                    Unreachable states: {analysis.unreachable.join(', ')}
+                  </p>
+                )}
+                {analysis.dead.length > 0 && (
+                  <p>
+                    Dead transitions:{' '}
+                    {analysis.dead
+                      .map(
+                        (t) =>
+                          `${states.find((s) => s.id === t.source)?.name}→${
+                            states.find((s) => s.id === t.target)?.name
+                          }`
+                      )
+                      .join(', ')}
+                  </p>
+                )}
+              </div>
+            )}
+
+            <div className="flex gap-2">
+              <Button onClick={runStep}>Step Simulation</Button>
+              <Button variant="outline" onClick={resetSimulation}>
+                Reset Simulation
+              </Button>
             </div>
 
             <div className="relative w-full h-96 bg-muted rounded-lg">
-              {states.map((state) => (
+              {states.map((state, idx) => (
                 <DraggableState
                   key={state.id}
                   id={state.id}
                   state={state}
                   onRemove={removeState}
+                  onClick={handleStateClick}
+                  selected={pendingTransition === state.id}
+                  encodingValue={encodeState(idx)}
                 />
               ))}
               <svg


### PR DESCRIPTION
## Summary
- allow interactive adding/removing of states and transitions
- visualize encoding schemes and toggle Moore/Mealy behavior
- add coverage tracking and checks for unreachable states

## Testing
- `npm test` *(fails: tests/e2e/curriculum-integrity.spec.ts:4:7 › Curriculum Links Integrity › all links on the main curriculum page should be navigable, ...)*
- `npm run lint`
- `npm run type-check` *(fails: src/components/animations/AssertionBuilder.tsx(43,19): error TS2345: Argument of type '{ operator: SvaOperator; status: string; }[]' is not assignable to parameter of type 'SetStateAction<{ operator: SvaOperator; status: "pass" | "fail"; }[]>'.)*

------
https://chatgpt.com/codex/tasks/task_e_689446af268483308304b5515e24c9db