### PR TITLE
Enhance coverage analyzer with traceability and reports

### DIFF
--- a/src/components/animations/coverage-data.ts
+++ b/src/components/animations/coverage-data.ts
@@ -1,8 +1,20 @@
+export interface CoverageBin {
+  name: string;
+  isCovered: boolean;
+}
+
+export interface Coverpoint {
+  name: string;
+  requirementId: string;
+  goal: number; // coverage goal in percent
+  bins: CoverageBin[];
+}
+
 export interface CoverageExample {
   name: string;
   code: string;
   steps: string[];
-  coverpoints: { name: string; bins: { name: string; isCovered: boolean }[] }[];
+  coverpoints: Coverpoint[];
 }
 
 export const coverageData: CoverageExample[] = [
@@ -17,6 +29,8 @@ export const coverageData: CoverageExample[] = [
     coverpoints: [
       {
         name: 'cp_data',
+        requirementId: 'REQ-CP1',
+        goal: 100,
         bins: [
           { name: 'auto[0]', isCovered: false },
           { name: 'auto[1]', isCovered: true },
@@ -36,6 +50,8 @@ export const coverageData: CoverageExample[] = [
     coverpoints: [
       {
         name: 'cp_data',
+        requirementId: 'REQ-CP2',
+        goal: 100,
         bins: [
           { name: 'low', isCovered: true },
           { name: 'high', isCovered: false },
@@ -54,6 +70,8 @@ export const coverageData: CoverageExample[] = [
     coverpoints: [
       {
         name: 'cross cp_a, cp_b',
+        requirementId: 'REQ-CROSS1',
+        goal: 100,
         bins: [
           { name: '(a=0,b=0)', isCovered: true },
           { name: '(a=0,b=1)', isCovered: false },


### PR DESCRIPTION
## Summary
- visualize cross coverage in 2D matrices or 3D slices
- track requirements with coverage goals and hole suggestions
- export coverage reports as JSON or HTML

## Testing
- `npm test` *(fails: curriculum pages and other e2e tests)*
- `npm run lint`
- `npm run type-check` *(fails: AssertionBuilder, RandomizationExplorer, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689446aad2dc83309c79e8a170043b5a