### PR TITLE
feat: enhance UVM timeline

### DIFF
--- a/src/components/diagrams/uvm-phasing-data.ts
+++ b/src/components/diagrams/uvm-phasing-data.ts
@@ -10,7 +10,7 @@ export interface UvmPhase {
   objectionTriggers?: { raise?: number; drop?: number };
 }
 
-export const uvmPhases: UvmPhase[] = [
+export let uvmPhases: UvmPhase[] = [
   // Build Phases (run in order, top-down)
   {
     name: 'build',
@@ -200,3 +200,7 @@ export const uvmPhases: UvmPhase[] = [
     timing: { start: 240, end: 250 },
   },
 ];
+
+export const addUvmPhase = (phase: UvmPhase) => {
+  uvmPhases = [...uvmPhases, phase];
+};


### PR DESCRIPTION
## Summary
- animate timeline marker and support keyboard navigation
- add modal for custom phases with export/share options
- allow data model to register new phases

## Testing
- `npm test` *(fails: tests/e2e/...)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689446a1cea48330a0d33bb1538b09b5