### PR TITLE
feat: enhance coverage analyzer

### DIFF
--- a/docs/components/CoverageAnalyzer.md
+++ b/docs/components/CoverageAnalyzer.md
@@ -1,0 +1,28 @@
+# CoverageAnalyzer
+
+The `CoverageAnalyzer` component demonstrates coverage-driven verification concepts in a visual, interactive way.
+
+## Interactive Controls
+
+- **Example Selector** – choose from coverage scenarios.
+- **Play/Pause/Reset** – dynamically collect coverage across steps.
+- **Next/Previous** – step through the verification flow manually.
+- **Download JSON/HTML** – export coverage reports.
+
+## Visualization
+
+- Cross coverage matrices highlight covered bins in green and holes in red.
+- Requirements progress bars track goals for each coverpoint.
+- Coverage holes list includes closure strategies for unmet bins.
+
+## Verification Flow
+
+The step display shows the coverage-driven verification process: define coverage model, collect coverage, analyze holes, and close coverage via targeted tests.
+
+## Usage Example
+
+```tsx
+import CoverageAnalyzer from '@/components/animations/CoverageAnalyzer';
+
+<CoverageAnalyzer />
+```


### PR DESCRIPTION
## Summary
- add play/pause coverage flow controls and step indicator
- highlight cross-coverage holes and include closure strategies in reports
- document CoverageAnalyzer interactive controls

## Testing
- `npm test` *(fails: Process from config.webServer exited early)*
- `npm run lint` *(fails: React hooks called conditionally in unrelated files)*
- `npm run type-check` *(fails: variable redeclarations and missing names in other modules)*

------
https://chatgpt.com/codex/tasks/task_e_6894ec06f26c83309d3e98c2eed67fe4