### PR TITLE
feat: Implement Learning Path Generator and Graph Highlighting

### DIFF
--- a/src/app/knowledge-hub/page.tsx
+++ b/src/app/knowledge-hub/page.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+'use client';
+
+import React, { useState } from 'react';
 import KnowledgeGraphVisualizer from '@/components/knowledge/KnowledgeGraphVisualizer';
 import ConceptRelationshipMapper from '@/components/knowledge/ConceptRelationshipMapper';
 import IntelligentCrossReference from '@/components/knowledge/IntelligentCrossReference';
@@ -6,6 +8,8 @@ import LearningPathGenerator from '@/components/knowledge/LearningPathGenerator'
 import ConceptDependencyAnalyzer from '@/components/knowledge/ConceptDependencyAnalyzer';
 
 const KnowledgeHubPage = () => {
+  const [highlightedPath, setHighlightedPath] = useState<string[]>([]);
+
   return (
     <div className="container mx-auto p-4">
       <header className="mb-10 text-center">
@@ -17,7 +21,7 @@ const KnowledgeHubPage = () => {
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
         <div className="lg:col-span-2">
-          <KnowledgeGraphVisualizer />
+          <KnowledgeGraphVisualizer highlightedPath={highlightedPath} />
         </div>
         <div className="bg-white shadow-md rounded-lg p-6">
           <ConceptRelationshipMapper />
@@ -26,7 +30,7 @@ const KnowledgeHubPage = () => {
           <IntelligentCrossReference />
         </div>
         <div className="bg-white shadow-md rounded-lg p-6">
-          <LearningPathGenerator />
+          <LearningPathGenerator onPathGenerated={setHighlightedPath} />
         </div>
         <div className="bg-white shadow-md rounded-lg p-6">
           <ConceptDependencyAnalyzer />

--- a/src/components/knowledge/LearningPathGenerator.tsx
+++ b/src/components/knowledge/LearningPathGenerator.tsx
@@ -1,13 +1,92 @@
-import React from 'react';
+'use client';
 
-const LearningPathGenerator = () => {
+import React, { useState, useEffect } from 'react';
+import {
+  getFullKnowledgeGraph,
+  generateLearningPath,
+  KnowledgeGraphData,
+  LearningPath,
+  ConceptNode,
+} from '@/lib/knowledge-graph-engine';
+
+interface LearningPathGeneratorProps {
+  onPathGenerated: (pathIds: string[]) => void;
+}
+
+const LearningPathGenerator = ({ onPathGenerated }: LearningPathGeneratorProps) => {
+  const [graphData, setGraphData] = useState<KnowledgeGraphData | null>(null);
+  const [startConcept, setStartConcept] = useState<string>('');
+  const [goalConcept, setGoalConcept] = useState<string>('');
+  const [learningPath, setLearningPath] = useState<LearningPath | null>(null);
+
+  useEffect(() => {
+    getFullKnowledgeGraph().then(data => {
+      setGraphData(data);
+      if (data.nodes.length > 1) {
+        setStartConcept('data_types');
+        setGoalConcept('uvm_sequences');
+      }
+    });
+  }, []);
+
+  const handleGeneratePath = () => {
+    if (graphData && startConcept && goalConcept) {
+      const result = generateLearningPath(graphData, startConcept, goalConcept);
+      setLearningPath(result);
+      onPathGenerated(result.path.map(node => node.id));
+    }
+  };
+
+  const ConceptSelector = ({ value, onChange, id, concepts }: { value: string, onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void, id: string, concepts: ConceptNode[] }) => (
+    <div>
+      <label htmlFor={id} className="block text-sm font-medium text-gray-700">
+        {id === 'start-concept' ? 'Starting Point' : 'Learning Goal'}
+      </label>
+      <select
+        id={id}
+        value={value}
+        onChange={onChange}
+        className="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md"
+      >
+        {concepts.map(node => (
+          <option key={node.id} value={node.id}>{node.name}</option>
+        ))}
+      </select>
+    </div>
+  );
+
   return (
-    <div className="p-4 border rounded-lg">
+    <div>
       <h2 className="text-xl font-bold mb-4">Learning Path Generator</h2>
-      <p>This component will generate personalized learning paths for users.</p>
-      {/* Placeholder for learning path UI */}
-      <div className="w-full h-64 bg-gray-200 rounded-md flex items-center justify-center">
-        <p className="text-gray-500">Learning path generation options and display will be here.</p>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+        {graphData && (
+          <>
+            <ConceptSelector id="start-concept" value={startConcept} onChange={e => setStartConcept(e.target.value)} concepts={graphData.nodes} />
+            <ConceptSelector id="goal-concept" value={goalConcept} onChange={e => setGoalConcept(e.target.value)} concepts={graphData.nodes} />
+          </>
+        )}
+      </div>
+      <button
+        onClick={handleGeneratePath}
+        className="w-full bg-indigo-600 text-white py-2 px-4 rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+      >
+        Generate Learning Path
+      </button>
+
+      <div className="mt-6">
+        <h3 className="text-lg font-semibold mb-2">Recommended Path:</h3>
+        {learningPath && learningPath.path.length > 0 && (
+          <ol className="list-decimal list-inside space-y-2 bg-gray-50 p-4 rounded-md">
+            {learningPath.path.map(node => (
+              <li key={node.id} className="text-gray-800">{node.name}</li>
+            ))}
+          </ol>
+        )}
+        {learningPath && learningPath.path.length === 0 && startConcept && goalConcept && (
+          <p className="text-gray-500 bg-gray-50 p-4 rounded-md">
+            No prerequisite path found from '{graphData?.nodes.find(n => n.id === startConcept)?.name}' to '{graphData?.nodes.find(n => n.id === goalConcept)?.name}'. Try different concepts.
+          </p>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
This commit introduces the complete Learning Path Generation feature, a core component of the knowledge management system. It includes the backend algorithm, the frontend UI, and the integration for visual feedback.

Key changes:
- **Learning Path Algorithm:** Implemented a Breadth-First Search (BFS) algorithm in `knowledge-graph-engine.ts` to find the shortest prerequisite path between two concepts.
- **Learning Path Generator UI:** Built the `LearningPathGenerator` component with dropdowns for selecting a start and goal concept, and a display area for the generated path.
- **Graph Path Highlighting:** Enhanced the `KnowledgeGraphVisualizer` to accept a `highlightedPath` prop, which it uses to visually distinguish the nodes and links of a given path.
- **Component Integration:** Lifted state to the parent `knowledge-hub` page to connect the generator and the visualizer. Generating a path now automatically highlights it on the graph.