### PR TITLE
feat: Add Just-in-Time Explanations for Concepts

### DIFF
--- a/src/app/curriculum/[...slug]/layout.tsx
+++ b/src/app/curriculum/[...slug]/layout.tsx
@@ -1,9 +1,18 @@
 import React from 'react';
+import { KnowledgeContextProvider } from '@/contexts/KnowledgeContext';
+import ConceptModal from '@/components/knowledge/ConceptModal';
 
 export default function CurriculumLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return <div className="p-4 md:p-6">{children}</div>;
+  return (
+    <KnowledgeContextProvider>
+      <div className="relative p-4 md:p-6">
+        {children}
+        <ConceptModal />
+      </div>
+    </KnowledgeContextProvider>
+  );
 }

--- a/src/components/knowledge/ConceptLink.tsx
+++ b/src/components/knowledge/ConceptLink.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useKnowledgeContext } from '@/contexts/KnowledgeContext';
 
 interface ConceptLinkProps {
   conceptId: string;
@@ -8,10 +9,15 @@ interface ConceptLinkProps {
 }
 
 const ConceptLink = ({ conceptId, children }: ConceptLinkProps) => {
+  const { setActiveConcept, getNodeById } = useKnowledgeContext();
+
   const handleClick = () => {
-    // In the future, this could open a modal or a side panel
-    // with a "just-in-time" explanation of the concept.
-    console.log(`Clicked concept: ${conceptId}`);
+    const conceptNode = getNodeById(conceptId);
+    if (conceptNode) {
+      setActiveConcept(conceptNode);
+    } else {
+      console.warn(`ConceptLink: Node with id "${conceptId}" not found.`);
+    }
   };
 
   return (

--- a/src/components/knowledge/ConceptModal.tsx
+++ b/src/components/knowledge/ConceptModal.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { useKnowledgeContext } from '@/contexts/KnowledgeContext';
+import { KnowledgeGraphData, getFullKnowledgeGraph, analyzeDependencies, DependencyAnalysis } from '@/lib/knowledge-graph-engine';
+
+const ConceptModal = () => {
+  const { activeConcept, setActiveConcept } = useKnowledgeContext();
+  const [graphData, setGraphData] = useState<KnowledgeGraphData | null>(null);
+  const [dependencies, setDependencies] = useState<DependencyAnalysis | null>(null);
+
+  useEffect(() => {
+    getFullKnowledgeGraph().then(setGraphData);
+  }, []);
+
+  useEffect(() => {
+    if (activeConcept && graphData) {
+      const analysis = analyzeDependencies(graphData, activeConcept.id);
+      setDependencies(analysis);
+    } else {
+      setDependencies(null);
+    }
+  }, [activeConcept, graphData]);
+
+  if (!activeConcept) {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed inset-0 bg-black bg-opacity-60 z-50 flex justify-center items-center"
+      onClick={() => setActiveConcept(null)}
+    >
+      <div
+        className="bg-gray-800 text-white rounded-lg shadow-2xl p-6 w-full max-w-2xl mx-4 transform transition-all"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex justify-between items-start mb-4">
+          <h2 className="text-2xl font-bold text-primary">{activeConcept.name}</h2>
+          <button
+            onClick={() => setActiveConcept(null)}
+            className="text-gray-400 hover:text-white text-2xl"
+          >
+            &times;
+          </button>
+        </div>
+
+        <p className="text-gray-300 mb-4">{activeConcept.description}</p>
+
+        {dependencies && dependencies.prerequisites.length > 0 && (
+          <div>
+            <h3 className="text-lg font-semibold mb-2">Prerequisites:</h3>
+            <ul className="list-disc list-inside bg-gray-700/50 p-3 rounded-md">
+              {dependencies.prerequisites.map(node => <li key={node.id}>{node.name}</li>)}
+            </ul>
+          </div>
+        )}
+
+      </div>
+    </div>
+  );
+};
+
+export default ConceptModal;

--- a/src/contexts/KnowledgeContext.tsx
+++ b/src/contexts/KnowledgeContext.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import React, { createContext, useState, useContext, ReactNode, useEffect } from 'react';
+import { ConceptNode, KnowledgeGraphData, getFullKnowledgeGraph } from '@/lib/knowledge-graph-engine';
+
+interface KnowledgeContextType {
+  graphData: KnowledgeGraphData | null;
+  activeConcept: ConceptNode | null;
+  setActiveConcept: (concept: ConceptNode | null) => void;
+  getNodeById: (id: string) => ConceptNode | undefined;
+}
+
+const KnowledgeContext = createContext<KnowledgeContextType | undefined>(undefined);
+
+export const KnowledgeContextProvider = ({ children }: { children: ReactNode }) => {
+  const [graphData, setGraphData] = useState<KnowledgeGraphData | null>(null);
+  const [activeConcept, setActiveConcept] = useState<ConceptNode | null>(null);
+
+  useEffect(() => {
+    getFullKnowledgeGraph().then(setGraphData);
+  }, []);
+
+  const getNodeById = (id: string): ConceptNode | undefined => {
+    return graphData?.nodes.find(node => node.id === id);
+  };
+
+  const value = {
+    graphData,
+    activeConcept,
+    setActiveConcept,
+    getNodeById,
+  };
+
+  return (
+    <KnowledgeContext.Provider value={value}>
+      {children}
+    </KnowledgeContext.Provider>
+  );
+};
+
+export const useKnowledgeContext = () => {
+  const context = useContext(KnowledgeContext);
+  if (context === undefined) {
+    throw new Error('useKnowledgeContext must be used within a KnowledgeContextProvider');
+  }
+  return context;
+};


### PR DESCRIPTION
This commit implements the 'just-in-time' concept explanation feature, allowing you to click on a linked concept within the curriculum and see its details in a modal.

Key changes:
- **`KnowledgeContext`:** A new React Context (`src/contexts/KnowledgeContext.tsx`) was created to manage the global state of the active concept, providing a clean way for components to communicate.
- **`ConceptModal` Component:** A new modal component (`src/components/knowledge/ConceptModal.tsx`) was built. It subscribes to the context and displays the active concept's details when available.
- **Enhanced `ConceptLink`:** The `ConceptLink` component was updated to use the context. On click, it now sets the active concept in the context, which triggers the modal to appear.
- **Provider Integration:** The `KnowledgeContextProvider` has been wrapped around the curriculum layout, making the context and modal functionality available across all learning content.