### PR TITLE
Fix hover fill class and add snapshot test

### DIFF
--- a/src/components/exercises/ScoreboardConnectorExercise.tsx
+++ b/src/components/exercises/ScoreboardConnectorExercise.tsx
@@ -193,7 +193,7 @@ const ScoreboardConnectorExercise: React.FC = () => {
                 fill={selectedPort?.portId === port.id ? "hsl(var(--accent))" : "hsl(var(--primary-foreground))"}
                 stroke="hsl(var(--primary))"
                 strokeWidth="1.5"
-                className="cursor-pointer hover:fill-hsl(var(--accent))"
+                className="cursor-pointer hover:fill-[hsl(var(--accent))]"
                 onClick={(e) => { e.stopPropagation(); handlePortClick(comp.id, port.id);}}
                 aria-label={`Port ${port.name} on ${comp.name}`}
               />

--- a/tests/components/ScoreboardConnectorExercise.test.tsx
+++ b/tests/components/ScoreboardConnectorExercise.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import ScoreboardConnectorExercise from '../../src/components/exercises/ScoreboardConnectorExercise';
+
+describe('ScoreboardConnectorExercise component', () => {
+  it('renders ports with hover accent fill class', () => {
+    const { getAllByLabelText, asFragment } = render(<ScoreboardConnectorExercise />);
+    const ports = getAllByLabelText(/Port .* on .*/);
+    for (const port of ports) {
+      expect(port).toHaveClass('hover:fill-[hsl(var(--accent))]');
+    }
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/tests/components/__snapshots__/ScoreboardConnectorExercise.test.tsx.snap
+++ b/tests/components/__snapshots__/ScoreboardConnectorExercise.test.tsx.snap
@@ -1,0 +1,129 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ScoreboardConnectorExercise component > renders ports with hover accent fill class 1`] = `
+<DocumentFragment>
+  <div
+    class="w-full max-w-2xl mx-auto p-4 bg-white/10 backdrop-blur-lg border border-white/20 rounded-lg shadow-lg"
+  >
+    <h3
+      class="text-lg font-semibold mb-4 text-center text-primary"
+    >
+      Connect the UVM Components
+    </h3>
+    <p
+      class="text-sm text-center text-muted-foreground mb-4"
+    >
+      Click on an output port (e.g., an analysis_port on a monitor) and then click on a compatible input port (e.g., an analysis_imp on a scoreboard or coverage collector) to make a connection.
+    </p>
+    <svg
+      class="border border-white/20 rounded bg-white/10"
+      height="400"
+      viewBox="0 0 600 400"
+      width="100%"
+    >
+      <g
+        transform="translate(50, 150)"
+      >
+        <rect
+          fill="hsla(var(--primary-foreground), 0.1)"
+          height="80"
+          rx="5"
+          stroke="hsl(var(--primary))"
+          stroke-width="1.5"
+          width="150"
+        />
+        <text
+          fill="hsl(var(--foreground))"
+          font-size="12"
+          text-anchor="middle"
+          x="75"
+          y="20"
+        >
+          UVM Monitor
+        </text>
+        <circle
+          aria-label="Port trans_ap on UVM Monitor"
+          class="cursor-pointer hover:fill-[hsl(var(--accent))]"
+          cx="145"
+          cy="40"
+          fill="hsl(var(--primary-foreground))"
+          r="8"
+          stroke="hsl(var(--primary))"
+          stroke-width="1.5"
+        />
+      </g>
+      <g
+        transform="translate(350, 50)"
+      >
+        <rect
+          fill="hsla(var(--primary-foreground), 0.1)"
+          height="80"
+          rx="5"
+          stroke="hsl(var(--primary))"
+          stroke-width="1.5"
+          width="150"
+        />
+        <text
+          fill="hsl(var(--foreground))"
+          font-size="12"
+          text-anchor="middle"
+          x="75"
+          y="20"
+        >
+          Scoreboard
+        </text>
+        <circle
+          aria-label="Port actual_trans_imp on Scoreboard"
+          class="cursor-pointer hover:fill-[hsl(var(--accent))]"
+          cx="5"
+          cy="40"
+          fill="hsl(var(--primary-foreground))"
+          r="8"
+          stroke="hsl(var(--primary))"
+          stroke-width="1.5"
+        />
+      </g>
+      <g
+        transform="translate(350, 250)"
+      >
+        <rect
+          fill="hsla(var(--primary-foreground), 0.1)"
+          height="80"
+          rx="5"
+          stroke="hsl(var(--primary))"
+          stroke-width="1.5"
+          width="150"
+        />
+        <text
+          fill="hsl(var(--foreground))"
+          font-size="12"
+          text-anchor="middle"
+          x="75"
+          y="20"
+        >
+          Coverage Collector
+        </text>
+        <circle
+          aria-label="Port observed_trans_imp on Coverage Collector"
+          class="cursor-pointer hover:fill-[hsl(var(--accent))]"
+          cx="5"
+          cy="40"
+          fill="hsl(var(--primary-foreground))"
+          r="8"
+          stroke="hsl(var(--primary))"
+          stroke-width="1.5"
+        />
+      </g>
+    </svg>
+    <div
+      class="mt-4 flex justify-center"
+    >
+      <button
+        class="inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-destructive text-destructive-foreground hover:bg-destructive/90 h-10 px-4 py-2"
+      >
+        Reset Connections
+      </button>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    include: ['tests/session-options.test.ts'],
+    include: ['tests/**/*.test.ts', 'tests/**/*.test.tsx'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- replace invalid hover fill with Tailwind-compatible `hover:fill-[hsl(var(--accent))]`
- expand vitest config and add snapshot test for hover styling

## Testing
- `npm test`
- `npm run build` *(fails: the name `useAsync` is defined multiple times in InteractiveUvmArchitectureDiagram.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68958aa0215c83308d8812cbe608e889