### PR TITLE
feat: add check order control to UVM phase sorter

### DIFF
--- a/tests/components/UvmPhaseSorterExercise.test.tsx
+++ b/tests/components/UvmPhaseSorterExercise.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect } from 'vitest';
+import UvmPhaseSorterExercise, { uvmPhases, shuffleArray } from '../../src/components/exercises/UvmPhaseSorterExercise';
+
+describe('UvmPhaseSorterExercise', () => {
+  it('detects correct sequence', async () => {
+    render(<UvmPhaseSorterExercise initialItems={uvmPhases} />);
+    const button = screen.getByRole('button', { name: /check order/i });
+    await userEvent.click(button);
+    expect(await screen.findByText(/correct order/i)).toBeInTheDocument();
+  });
+
+  it('detects incorrect sequence', async () => {
+    let shuffled = shuffleArray(uvmPhases);
+    while (shuffled.every((p, i) => p.id === uvmPhases[i].id)) {
+      shuffled = shuffleArray(uvmPhases);
+    }
+    render(<UvmPhaseSorterExercise initialItems={shuffled} />);
+    const button = screen.getByRole('button', { name: /check order/i });
+    await userEvent.click(button);
+    expect(await screen.findByText(/incorrect order/i)).toBeInTheDocument();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    include: ['tests/session-options.test.ts'],
+    include: ['tests/**/*.test.ts?(x)'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- add "Check Order" button and feedback/reset options to UVM phase sorter exercise
- test phase sorter for correct and incorrect sequences
- run all tests with updated vitest config

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68958aa2f2ec83309569f97942589114