### PR TITLE
feat: add UVM agent validation exercise

### DIFF
--- a/tests/components/UvmAgentBuilderExercise.test.ts
+++ b/tests/components/UvmAgentBuilderExercise.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { checkAgentComponents, Item } from '@/components/exercises/UvmAgentBuilderExercise';
+
+describe('checkAgentComponents', () => {
+  it('warns when required components are missing', () => {
+    const agent: Item[] = [{ id: 'sequencer', name: 'Sequencer' }];
+    const result = checkAgentComponents(agent);
+    expect(result.warnings).toContain('Missing components: Driver, Monitor');
+  });
+
+  it('warns when components are out of order', () => {
+    const agent: Item[] = [
+      { id: 'driver', name: 'Driver' },
+      { id: 'sequencer', name: 'Sequencer' },
+      { id: 'monitor', name: 'Monitor' },
+    ];
+    const result = checkAgentComponents(agent);
+    expect(result.warnings).toContain('Components are not in the correct order.');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    include: ['tests/session-options.test.ts'],
+    include: ['tests/session-options.test.ts', 'tests/components/**/*.test.ts'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- validate agent builds against required sequencer/driver/monitor set
- add helper to score agent components and show feedback button
- add unit tests covering missing or misordered agent components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68958aa3da088330a2670755926c2980