### PR TITLE
Add feedback loop to exercises and tests

### DIFF
--- a/src/app/exercises/scoreboard-connector/page.tsx
+++ b/src/app/exercises/scoreboard-connector/page.tsx
@@ -28,7 +28,7 @@ const ScoreboardConnectorPage: React.FC = () => {
           <li>Visualize how monitors broadcast transactions to multiple subscribers.</li>
           <li>Practice a key aspect of UVM testbench connectivity.</li>
         </ul>
-        {/* TODO: Add Scoring, Feedback, and Retry button integration in later steps */}
+        <p className="text-muted-foreground mt-4">Use Check to evaluate your connections and Retry to start over.</p>
       </section>
     </>
   );

--- a/src/app/exercises/uvm-agent-builder/page.tsx
+++ b/src/app/exercises/uvm-agent-builder/page.tsx
@@ -28,7 +28,7 @@ const UvmAgentBuilderPage: React.FC = () => {
           <li>Understand the typical internal structure of an agent.</li>
           <li>Practice visual assembly of a key UVM architectural pattern.</li>
         </ul>
-        {/* TODO: Add Scoring, Feedback, and Retry button integration in later steps */}
+        <p className="text-muted-foreground mt-4">Check your build and use Retry to start over.</p>
       </section>
     </>
   );

--- a/src/app/exercises/uvm-phase-sorter/page.tsx
+++ b/src/app/exercises/uvm-phase-sorter/page.tsx
@@ -28,7 +28,7 @@ const UvmPhaseSorterPage: React.FC = () => {
           <li>Understand the sequential nature of UVM phasing.</li>
           <li>Practice organizing a key aspect of UVM testbench flow.</li>
         </ul>
-        {/* TODO: Add Scoring, Feedback, and Retry button integration in later steps */}
+        <p className="text-muted-foreground mt-4">Use the Check button to evaluate your order and Retry to try again.</p>
       </section>
     </>
   );

--- a/src/components/exercises/ScoreboardConnectorExercise.tsx
+++ b/src/components/exercises/ScoreboardConnectorExercise.tsx
@@ -56,6 +56,7 @@ const ScoreboardConnectorExercise: React.FC = () => {
   const [drawingLine, setDrawingLine] = useState<{ fromComponentId: string; fromPortId: string; x1: number; y1: number; x2: number; y2: number } | null>(null);
   const [selectedPort, setSelectedPort] = useState<{ componentId: string; portId: string } | null>(null);
   const svgRef = useRef<SVGSVGElement>(null);
+  const [feedback, setFeedback] = useState<{ score: number; passed: boolean } | null>(null);
 
   const getPortAbsolutePosition = (componentId: string, portId: string) => {
     const component = components.find(c => c.id === componentId);
@@ -125,8 +126,28 @@ const ScoreboardConnectorExercise: React.FC = () => {
         setDrawingLine(null);
     }
   }
+  const expectedConnections: Connection[] = [
+    { fromComponentId: 'monitor', fromPortId: 'mon_ap', toComponentId: 'scoreboard', toPortId: 'sb_imp_actual' },
+    { fromComponentId: 'monitor', fromPortId: 'mon_ap', toComponentId: 'coverage', toPortId: 'cov_imp' },
+  ];
 
-  // TODO: Add validation, scoring, feedback, retry
+  const isMatch = (a: Connection, b: Connection) =>
+    (a.fromComponentId === b.fromComponentId && a.fromPortId === b.fromPortId && a.toComponentId === b.toComponentId && a.toPortId === b.toPortId) ||
+    (a.fromComponentId === b.toComponentId && a.fromPortId === b.toPortId && a.toComponentId === b.fromComponentId && a.toPortId === b.fromPortId);
+
+  const checkConnections = () => {
+    let correct = 0;
+    expectedConnections.forEach(exp => {
+      if (connections.some(conn => isMatch(conn, exp))) correct++;
+    });
+    const score = Math.round((correct / expectedConnections.length) * 100);
+    setFeedback({ score, passed: score === 100 });
+  };
+
+  const handleRetry = () => {
+    setConnections([]);
+    setFeedback(null);
+  };
 
   return (
     <div className="w-full max-w-2xl mx-auto p-4 bg-white/10 backdrop-blur-lg border border-white/20 rounded-lg shadow-lg">
@@ -201,15 +222,18 @@ const ScoreboardConnectorExercise: React.FC = () => {
           </g>
         ))}
       </svg>
-       <div className="mt-4 flex justify-center">
-        <Button
-            onClick={() => setConnections([])}
-            variant="destructive"
-        >
-            Reset Connections
-        </Button>
-        {/* TODO: Add Check Connections button */}
+      <div className="mt-4 flex justify-center gap-2">
+        <Button onClick={checkConnections}>Check Connections</Button>
+        <Button variant="outline" onClick={handleRetry}>Retry</Button>
       </div>
+      {feedback && (
+        <div className="mt-4 text-center">
+          <p>Score: {feedback.score}%</p>
+          <p className={feedback.passed ? 'text-green-500' : 'text-red-500'}>
+            {feedback.passed ? 'Pass' : 'Fail'}
+          </p>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/exercises/UvmAgentBuilderExercise.tsx
+++ b/src/components/exercises/UvmAgentBuilderExercise.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, useSensors, DragEndEvent, DraggableSyntheticListeners, DraggableAttributes } from '@dnd-kit/core';
 import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import { Button } from '@/components/ui/Button';
 
 interface Item {
   id: string;
@@ -66,7 +67,8 @@ const UvmAgentBuilderExercise: React.FC = () => {
 
   const [availableComponents, setAvailableComponents] = useState<Item[]>(initialComponents);
   const [agentComponents, setAgentComponents] = useState<Item[]>([]);
-   const [activeId, setActiveId] = useState<string | null>(null);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [feedback, setFeedback] = useState<{ score: number; passed: boolean } | null>(null);
 
 
   const sensors = useSensors(
@@ -135,58 +137,85 @@ const UvmAgentBuilderExercise: React.FC = () => {
   }
 
   const activeItem = getActiveItem();
+  const requiredIds = ['sequencer', 'driver', 'monitor'];
+
+  const checkAgent = () => {
+    const correct = requiredIds.filter(id => agentComponents.some(item => item.id === id)).length;
+    const score = Math.round((correct / requiredIds.length) * 100);
+    setFeedback({ score, passed: score === 100 });
+  };
+
+  const handleRetry = () => {
+    setAvailableComponents(initialComponents);
+    setAgentComponents([]);
+    setFeedback(null);
+  };
 
   return (
-    <DndContext
-      sensors={sensors}
-      collisionDetection={closestCenter}
-      onDragStart={handleDragStart}
-      onDragEnd={handleDragEnd}
-    >
-      <div className="flex flex-col md:flex-row gap-6 p-4 items-start">
-        {/* Available Components */}
-        <div className="w-full md:w-1/3 p-4 bg-white/10 backdrop-blur-lg border border-white/20 rounded-lg shadow-lg">
-          <h3 className="text-lg font-semibold mb-3 text-primary">Available UVM Components</h3>
-          <SortableContext items={availableComponents.map(i => i.id)} strategy={verticalListSortingStrategy} id="available-droppable">
-             <div id="available-droppable" className="min-h-[200px] border-2 border-dashed border-white/20 rounded p-2">
-                {availableComponents.map(item => <SortableItem key={item.id} item={item} />)}
-                {availableComponents.length === 0 && <p className="text-muted-foreground text-center py-4">All components used.</p>}
-             </div>
-          </SortableContext>
-        </div>
-
-        {/* Agent Target Area */}
-        <div className="w-full md:w-2/3 p-4 bg-white/10 backdrop-blur-lg border-2 border-accent rounded-lg shadow-lg">
-          <h3 className="text-lg font-semibold mb-3 text-accent">UVM Agent (Drop Zone)</h3>
-           <SortableContext items={agentComponents.map(i => i.id)} strategy={verticalListSortingStrategy} id="agent-droppable">
-            <div id="agent-droppable" className="min-h-[200px] p-2 bg-white/10 rounded border border-dashed border-accent">
-                {agentComponents.map(item => <SortableItem key={item.id} item={item} />)}
-                {agentComponents.length === 0 && <p className="text-muted-foreground text-center py-4">Drag components here</p>}
-            </div>
-          </SortableContext>
-        </div>
-      </div>
-       {typeof document !== 'undefined' && activeId && (
-          <div style={{position: 'fixed', top: 0, left: 0, pointerEvents: 'none', zIndex: 1000}}>
-            {/* This is a simplified drag overlay. For a perfect overlay matching the item,
-                you'd use <DragOverlay> from @dnd-kit/core andPortal={document.body} */}
-            {activeItem &&
-              <DraggableItem
-                item={activeItem}
-                isOverlay={true}
-                attributes={{
-                  role: 'button', // Or appropriate role for a draggable item
-                  'aria-roledescription': 'draggable item',
-                  tabIndex: -1,
-                  'aria-disabled': true,
-                  'aria-pressed': undefined,
-                  'aria-describedby': 'draggable-item-description', // A bit generic, but satisfies type
-                }}
-                style={{}}
-              />}
+    <>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+      >
+        <div className="flex flex-col md:flex-row gap-6 p-4 items-start">
+          {/* Available Components */}
+          <div className="w-full md:w-1/3 p-4 bg-white/10 backdrop-blur-lg border border-white/20 rounded-lg shadow-lg">
+            <h3 className="text-lg font-semibold mb-3 text-primary">Available UVM Components</h3>
+            <SortableContext items={availableComponents.map(i => i.id)} strategy={verticalListSortingStrategy} id="available-droppable">
+               <div id="available-droppable" className="min-h-[200px] border-2 border-dashed border-white/20 rounded p-2">
+                  {availableComponents.map(item => <SortableItem key={item.id} item={item} />)}
+                  {availableComponents.length === 0 && <p className="text-muted-foreground text-center py-4">All components used.</p>}
+               </div>
+            </SortableContext>
           </div>
-        )}
-    </DndContext>
+
+          {/* Agent Target Area */}
+          <div className="w-full md:w-2/3 p-4 bg-white/10 backdrop-blur-lg border-2 border-accent rounded-lg shadow-lg">
+            <h3 className="text-lg font-semibold mb-3 text-accent">UVM Agent (Drop Zone)</h3>
+             <SortableContext items={agentComponents.map(i => i.id)} strategy={verticalListSortingStrategy} id="agent-droppable">
+              <div id="agent-droppable" className="min-h-[200px] p-2 bg-white/10 rounded border border-dashed border-accent">
+                  {agentComponents.map(item => <SortableItem key={item.id} item={item} />)}
+                  {agentComponents.length === 0 && <p className="text-muted-foreground text-center py-4">Drag components here</p>}
+              </div>
+            </SortableContext>
+          </div>
+        </div>
+         {typeof document !== 'undefined' && activeId && (
+            <div style={{position: 'fixed', top: 0, left: 0, pointerEvents: 'none', zIndex: 1000}}>
+              {/* This is a simplified drag overlay. For a perfect overlay matching the item,
+                  you'd use <DragOverlay> from @dnd-kit/core andPortal={document.body} */}
+              {activeItem &&
+                <DraggableItem
+                  item={activeItem}
+                  isOverlay={true}
+                  attributes={{
+                    role: 'button', // Or appropriate role for a draggable item
+                    'aria-roledescription': 'draggable item',
+                    tabIndex: -1,
+                    'aria-disabled': true,
+                    'aria-pressed': undefined,
+                    'aria-describedby': 'draggable-item-description', // A bit generic, but satisfies type
+                  }}
+                  style={{}}
+                />}
+            </div>
+          )}
+      </DndContext>
+      <div className="mt-4 flex justify-center gap-2">
+        <Button onClick={checkAgent}>Check Agent</Button>
+        <Button variant="outline" onClick={handleRetry}>Retry</Button>
+      </div>
+      {feedback && (
+        <div className="mt-4 text-center">
+          <p>Score: {feedback.score}%</p>
+          <p className={feedback.passed ? 'text-green-500' : 'text-red-500'}>
+            {feedback.passed ? 'Pass' : 'Fail'}
+          </p>
+        </div>
+      )}
+    </>
   );
 };
 

--- a/src/components/exercises/UvmPhaseSorterExercise.tsx
+++ b/src/components/exercises/UvmPhaseSorterExercise.tsx
@@ -21,6 +21,7 @@ import {
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { GripVertical } from 'lucide-react'; // For drag handle
+import { Button } from '@/components/ui/Button';
 
 interface Phase {
   id: UniqueIdentifier; // Use UniqueIdentifier from dnd-kit
@@ -109,6 +110,7 @@ const SortablePhaseItem: React.FC<SortablePhaseItemProps> = ({ phase }) => {
 const UvmPhaseSorterExercise: React.FC = () => {
   const [items, setItems] = useState<Phase[]>([]);
   const [activeItem, setActiveItem] = useState<Phase | null>(null);
+  const [feedback, setFeedback] = useState<{ score: number; passed: boolean } | null>(null);
 
   useEffect(() => {
     setItems(shuffleArray(uvmPhases));
@@ -139,33 +141,57 @@ const UvmPhaseSorterExercise: React.FC = () => {
     }
   }
 
+  const checkOrder = () => {
+    const correct = items.filter((item, idx) => item.correctOrder === idx).length;
+    const score = Math.round((correct / items.length) * 100);
+    setFeedback({ score, passed: score === 100 });
+  };
+
+  const handleRetry = () => {
+    setItems(shuffleArray(uvmPhases));
+    setFeedback(null);
+  };
+
   return (
-    <DndContext
-      sensors={sensors}
-      collisionDetection={closestCenter}
-      onDragStart={handleDragStart}
-      onDragEnd={handleDragEnd}
-    >
-      <div className="w-full max-w-md mx-auto p-4 bg-white/10 backdrop-blur-lg border border-white/20 rounded-lg shadow-lg">
-        <h3 className="text-lg font-semibold mb-4 text-center text-primary">Sort the UVM Phases</h3>
-        <SortableContext items={items.map(item => item.id)} strategy={verticalListSortingStrategy}>
-          <div className="space-y-2">
-            {items.map((phase) => (
-              <SortablePhaseItem key={phase.id} phase={phase} />
-            ))}
-          </div>
-        </SortableContext>
-        <DragOverlay>
-          {activeItem ? (
-            <div className="flex items-center p-3 mb-2 bg-primary text-primary-foreground rounded-md border border-white/20 shadow-xl cursor-grabbing">
-               <GripVertical size={20} className="mr-3"/>
-              <span>{activeItem.name}</span>
+    <>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+      >
+        <div className="w-full max-w-md mx-auto p-4 bg-white/10 backdrop-blur-lg border border-white/20 rounded-lg shadow-lg">
+          <h3 className="text-lg font-semibold mb-4 text-center text-primary">Sort the UVM Phases</h3>
+          <SortableContext items={items.map(item => item.id)} strategy={verticalListSortingStrategy}>
+            <div className="space-y-2">
+              {items.map((phase) => (
+                <SortablePhaseItem key={phase.id} phase={phase} />
+              ))}
             </div>
-          ) : null}
-        </DragOverlay>
+          </SortableContext>
+          <DragOverlay>
+            {activeItem ? (
+              <div className="flex items-center p-3 mb-2 bg-primary text-primary-foreground rounded-md border border-white/20 shadow-xl cursor-grabbing">
+                 <GripVertical size={20} className="mr-3"/>
+                <span>{activeItem.name}</span>
+              </div>
+            ) : null}
+          </DragOverlay>
+        </div>
+      </DndContext>
+      <div className="mt-4 flex justify-center gap-2">
+        <Button onClick={checkOrder}>Check Order</Button>
+        <Button variant="outline" onClick={handleRetry}>Retry</Button>
       </div>
-      {/* TODO: Add Check Order Button, Feedback, Score, Retry */}
-    </DndContext>
+      {feedback && (
+        <div className="mt-4 text-center">
+          <p>Score: {feedback.score}%</p>
+          <p className={feedback.passed ? 'text-green-500' : 'text-red-500'}>
+            {feedback.passed ? 'Pass' : 'Fail'}
+          </p>
+        </div>
+      )}
+    </>
   );
 };
 

--- a/tests/e2e/exercise-feedback.spec.ts
+++ b/tests/e2e/exercise-feedback.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Exercise Feedback Flow', () => {
+  test('UVM Phase Sorter provides feedback and retry', async ({ page }) => {
+    await page.goto('/exercises/uvm-phase-sorter');
+    await page.getByRole('button', { name: 'Check Order' }).click();
+    const scoreText = page.locator('text=Score');
+    await expect(scoreText).toBeVisible();
+    await page.getByRole('button', { name: 'Retry' }).click();
+    await expect(scoreText).toHaveCount(0);
+  });
+
+  test('Scoreboard Connector passes when connections are correct and can retry', async ({ page }) => {
+    await page.goto('/exercises/scoreboard-connector');
+    await page.getByLabel('Port trans_ap on UVM Monitor').click();
+    await page.getByLabel('Port actual_trans_imp on Scoreboard').click();
+    await page.getByLabel('Port trans_ap on UVM Monitor').click();
+    await page.getByLabel('Port observed_trans_imp on Coverage Collector').click();
+    await page.getByRole('button', { name: 'Check Connections' }).click();
+    const passText = page.locator('text=Pass');
+    await expect(passText).toBeVisible();
+    await page.getByRole('button', { name: 'Retry' }).click();
+    await expect(passText).toHaveCount(0);
+  });
+
+  test('UVM Agent Builder evaluates components and resets on retry', async ({ page }) => {
+    await page.goto('/exercises/uvm-agent-builder');
+    const agentDrop = page.locator('#agent-droppable');
+    await page.getByText('Sequencer').dragTo(agentDrop);
+    await page.getByText('Driver').dragTo(agentDrop);
+    await page.getByText('Monitor').dragTo(agentDrop);
+    await page.getByRole('button', { name: 'Check Agent' }).click();
+    const passText = page.locator('text=Pass');
+    await expect(passText).toBeVisible();
+    await page.getByRole('button', { name: 'Retry' }).click();
+    await expect(passText).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Wire Check and Retry feedback loops for phase sorter, scoreboard connector, and agent builder exercises
- Provide pass/fail scoring feedback on each exercise
- Add Playwright e2e tests covering feedback flows

## Testing
- `npm run lint` *(fails: React hooks called conditionally in other modules)*
- `npm test`
- `npm run test:e2e -- tests/e2e/exercise-feedback.spec.ts` *(fails: duplicate hook imports in InteractiveUvmArchitectureDiagram.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68958aa57944833098f4e7c81668232b