### PR TITLE
feat: include page context in AI assistant requests

### DIFF
--- a/src/components/widgets/AIAssistantWidget.tsx
+++ b/src/components/widgets/AIAssistantWidget.tsx
@@ -51,7 +51,7 @@ const AIAssistantWidget: React.FC = () => {
     setInputValue(event.target.value);
   };
 
-  const handleSubmit = async (event?: FormEvent<HTMLFormElement>) => {
+  const handleSendMessage = async (event?: FormEvent<HTMLFormElement>) => {
     if (event) event.preventDefault();
     const trimmedInput = inputValue.trim();
     if (!trimmedInput) return;
@@ -66,9 +66,13 @@ const AIAssistantWidget: React.FC = () => {
     setInputValue("");
     setIsLoading(true);
 
-    // TODO: Implement actual page context extraction
-    const pageContext = "Placeholder: Current page content will be extracted here.";
-    const systemPrompt = "You are an expert-level verification engineer with 20 years of experience in SystemVerilog and UVM. You are a helpful tutor. Explain complex concepts clearly and concisely. Always refer to the provided context before answering.";
+    const context = {
+      pageTitle: document.title,
+      route: window.location.pathname,
+      selectedText: window.getSelection()?.toString() || "",
+    };
+    const systemPrompt =
+      "You are an expert-level verification engineer with 20 years of experience in SystemVerilog and UVM. You are a helpful tutor. Explain complex concepts clearly and concisely. Always refer to the provided context before answering.";
 
     try {
       const response = await fetch('/api/ai/chat', {
@@ -78,7 +82,7 @@ const AIAssistantWidget: React.FC = () => {
         },
         body: JSON.stringify({
           systemPrompt,
-          pageContext,
+          context,
           userQuestion: trimmedInput,
         }),
       });
@@ -96,12 +100,13 @@ const AIAssistantWidget: React.FC = () => {
         timestamp: new Date(),
       };
       setMessages((prevMessages) => [...prevMessages, assistantResponse]);
-
     } catch (error) {
       console.error("Failed to get AI response:", error);
       const errorMessage: Message = {
         id: `err-${Date.now()}`,
-        text: `Sorry, I encountered an error. ${error instanceof Error ? error.message : 'Please try again.'}`,
+        text: `Sorry, I encountered an error. ${
+          error instanceof Error ? error.message : 'Please try again.'
+        }`,
         sender: "assistant", // Error shown as an assistant message
         timestamp: new Date(),
       };
@@ -215,7 +220,7 @@ const AIAssistantWidget: React.FC = () => {
             </div>
 
             {/* Input Area */}
-            <form onSubmit={handleSubmit} className="p-3 border-t border-border/50 bg-background/50 dark:bg-background/30">
+            <form onSubmit={handleSendMessage} className="p-3 border-t border-border/50 bg-background/50 dark:bg-background/30">
               <div className="flex items-end space-x-2">
                 <Textarea
                   value={inputValue}
@@ -223,7 +228,7 @@ const AIAssistantWidget: React.FC = () => {
                   onKeyDown={(e) => {
                     if (e.key === 'Enter' && !e.shiftKey) {
                       e.preventDefault();
-                      handleSubmit();
+                      handleSendMessage();
                     }
                   }}
                   placeholder="Ask about SystemVerilog, UVM..."

--- a/tests/components/AIAssistantWidget.test.tsx
+++ b/tests/components/AIAssistantWidget.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import AIAssistantWidget from '../../src/components/widgets/AIAssistantWidget';
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { displayName: 'Tester' } }),
+}));
+
+describe('AIAssistantWidget page context', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({ reply: 'ok' }) }) as any,
+    ));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('includes page title, route, and selected text in request', async () => {
+    document.title = 'Test Title';
+    window.history.pushState({}, '', '/test-route');
+    vi.spyOn(window, 'getSelection').mockReturnValue({ toString: () => 'selected text' } as any);
+    (window.HTMLElement as any).prototype.scrollIntoView = vi.fn();
+
+    render(<AIAssistantWidget />);
+
+    const openButton = screen.getByRole('button', { name: /open ai assistant/i });
+    await userEvent.click(openButton);
+
+    const textarea = await screen.findByPlaceholderText(/ask about systemverilog, uvm/i);
+    await userEvent.type(textarea, 'Hello there');
+
+    const sendButton = screen.getByRole('button', { name: /send message/i });
+    await userEvent.click(sendButton);
+
+    const fetchMock = fetch as unknown as vi.Mock;
+    expect(fetchMock).toHaveBeenCalled();
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.context).toEqual({
+      pageTitle: 'Test Title',
+      route: '/test-route',
+      selectedText: 'selected text',
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    include: ['tests/session-options.test.ts'],
+    include: ['tests/**/*.test.ts', 'tests/**/*.test.tsx'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- capture page title, route, and selected text when sending messages in AI assistant
- send captured context to `/api/ai/chat` for richer responses
- add tests verifying request payload includes page context and expand Vitest config to run all tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68958aa7a124833087c290241f6ec0f3