### PR TITLE
Implement challenge solutions with tests

### DIFF
--- a/src/lib/challenges/index.ts
+++ b/src/lib/challenges/index.ts
@@ -9,6 +9,7 @@ export const challenges: Challenge[] = [
     starterCode: `function solution(a: number, b: number) {
   // TODO: return the sum of a and b
 }`,
+    solution: (a: number, b: number): number => a + b,
     testCases: [
       { input: [1, 2], expected: 3 },
       { input: [5, 7], expected: 12 }
@@ -22,6 +23,16 @@ export const challenges: Challenge[] = [
     starterCode: `function solution(n: number) {
   // TODO: return n!
 }`,
+    solution: (n: number): number => {
+      if (!Number.isInteger(n) || n < 0) {
+        throw new Error("n must be a non-negative integer");
+      }
+      let result = 1;
+      for (let i = 2; i <= n; i++) {
+        result *= i;
+      }
+      return result;
+    },
     testCases: [
       { input: [3], expected: 6 },
       { input: [5], expected: 120 }
@@ -35,6 +46,20 @@ export const challenges: Challenge[] = [
     starterCode: `function solution(n: number) {
   // TODO: return the nth fibonacci number
 }`,
+    solution: (n: number): number => {
+      if (!Number.isInteger(n) || n < 0) {
+        throw new Error("n must be a non-negative integer");
+      }
+      if (n <= 1) return n;
+      let prev = 0;
+      let curr = 1;
+      for (let i = 2; i <= n; i++) {
+        const next = prev + curr;
+        prev = curr;
+        curr = next;
+      }
+      return curr;
+    },
     testCases: [
       { input: [5], expected: 5 },
       { input: [10], expected: 55 }

--- a/src/lib/challenges/types.ts
+++ b/src/lib/challenges/types.ts
@@ -11,5 +11,10 @@ export interface Challenge {
   description: string;
   difficulty: Difficulty;
   starterCode: string;
+  /**
+   * Reference implementation used for automated tests.
+   * Receives the challenge inputs and returns the result.
+   */
+  solution: (...args: any[]) => any;
   testCases: TestCase[];
 }

--- a/tests/challenges.test.ts
+++ b/tests/challenges.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { challenges } from '@/lib/challenges';
+
+function getSolution(id: string) {
+  const challenge = challenges.find((c) => c.id === id);
+  if (!challenge) throw new Error('Challenge not found');
+  return challenge.solution;
+}
+
+describe('challenge solutions', () => {
+  it('add-two sums numbers correctly', () => {
+    const addTwo = getSolution('add-two');
+    expect(addTwo(1, 2)).toBe(3);
+    expect(addTwo(-1, 1)).toBe(0);
+  });
+
+  it('factorial handles non-negative integers and rejects negatives', () => {
+    const factorial = getSolution('factorial');
+    expect(factorial(0)).toBe(1);
+    expect(factorial(5)).toBe(120);
+    expect(() => factorial(-1)).toThrow();
+  });
+
+  it('fibonacci computes sequence and rejects negatives', () => {
+    const fibonacci = getSolution('fibonacci');
+    expect(fibonacci(0)).toBe(0);
+    expect(fibonacci(10)).toBe(55);
+    expect(() => fibonacci(-5)).toThrow();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    include: ['tests/session-options.test.ts'],
+    include: ['tests/**/*.test.ts'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- add reference implementations for Add Two Numbers, Factorial, and Fibonacci challenges
- cover edge cases for negative inputs
- expand Vitest config and add unit tests for challenge solutions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68958aa92e38833080a88575654ec621