### PR TITLE
Use env vars for Firebase configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,21 @@ Deploying via Vercel works out of the box using the `next start` command. The `o
 
 If exporting with `next export`, guard any `window` usage as it only runs client-side.
 
+## Firebase Configuration
+
+The application expects Firebase credentials to be provided via environment variables. Create a `.env.local` file (or otherwise set these values) with the following keys:
+
+```
+NEXT_PUBLIC_FIREBASE_API_KEY=your_api_key
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your_auth_domain
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=your_project_id
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your_storage_bucket
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=your_messaging_sender_id
+NEXT_PUBLIC_FIREBASE_APP_ID=your_app_id
+```
+
+These variables are used during initialization in `src/lib/firebase.ts`.
+
 ## Phase Deliverables
 
 * [Enhancement Blueprint](enhance.md)

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,18 +1,17 @@
-// TODO: Replace with your actual Firebase configuration
-const firebaseConfig = {
-  apiKey: "YOUR_API_KEY",
-  authDomain: "YOUR_AUTH_DOMAIN",
-  projectId: "YOUR_PROJECT_ID",
-  storageBucket: "YOUR_STORAGE_BUCKET",
-  messagingSenderId: "YOUR_MESSAGING_SENDER_ID",
-  appId: "YOUR_APP_ID"
-};
-
-import { initializeApp } from "firebase/app";
+import { initializeApp, getApps, getApp } from "firebase/app";
 import { getFirestore } from "firebase/firestore";
 import { getAuth } from "firebase/auth";
 
-const app = initializeApp(firebaseConfig);
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID
+};
+
+const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
 const db = getFirestore(app);
 const auth = getAuth(app);
 

--- a/src/lib/firebaseConfig.mock.ts
+++ b/src/lib/firebaseConfig.mock.ts
@@ -2,13 +2,13 @@
 // When you set up your actual Firebase project, replace this with the real config.
 
 export const firebaseConfigMock = {
-  apiKey: "MOCK_API_KEY",
-  authDomain: "mock-project-id.firebaseapp.com",
-  projectId: "mock-project-id",
-  storageBucket: "mock-project-id.appspot.com",
-  messagingSenderId: "MOCK_MESSAGING_SENDER_ID",
-  appId: "MOCK_APP_ID",
-  measurementId: "MOCK_MEASUREMENT_ID" // Optional, for Analytics
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY || "MOCK_API_KEY",
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN || "mock-project-id.firebaseapp.com",
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID || "mock-project-id",
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET || "mock-project-id.appspot.com",
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID || "MOCK_MESSAGING_SENDER_ID",
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID || "MOCK_APP_ID",
+  measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID || "MOCK_MEASUREMENT_ID" // Optional, for Analytics
 };
 
 // In a real setup, you would initialize Firebase like this:

--- a/tests/firebase.test.ts
+++ b/tests/firebase.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const { initSpy } = vi.hoisted(() => {
+  return { initSpy: vi.fn() };
+});
+
+vi.mock('firebase/app', () => ({
+  initializeApp: initSpy,
+  getApps: () => [],
+  getApp: vi.fn(),
+}));
+vi.mock('firebase/firestore', () => ({ getFirestore: vi.fn(() => ({})) }));
+vi.mock('firebase/auth', () => ({ getAuth: vi.fn(() => ({})) }));
+
+const setEnv = () => {
+  process.env.NEXT_PUBLIC_FIREBASE_API_KEY = 'test-api-key';
+  process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN = 'test.firebaseapp.com';
+  process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID = 'test-project';
+  process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET = 'test.appspot.com';
+  process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID = 'test-sender';
+  process.env.NEXT_PUBLIC_FIREBASE_APP_ID = 'test-app-id';
+};
+
+const clearEnv = () => {
+  delete process.env.NEXT_PUBLIC_FIREBASE_API_KEY;
+  delete process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN;
+  delete process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
+  delete process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET;
+  delete process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID;
+  delete process.env.NEXT_PUBLIC_FIREBASE_APP_ID;
+};
+
+describe('firebase initialization', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    initSpy.mockReset();
+    setEnv();
+  });
+
+  afterEach(() => {
+    clearEnv();
+  });
+
+  it('initializes Firebase with environment config', async () => {
+    const mod = await import('@/lib/firebase');
+
+    expect(initSpy).toHaveBeenCalledWith({
+      apiKey: 'test-api-key',
+      authDomain: 'test.firebaseapp.com',
+      projectId: 'test-project',
+      storageBucket: 'test.appspot.com',
+      messagingSenderId: 'test-sender',
+      appId: 'test-app-id'
+    });
+    expect(mod.db).toBeDefined();
+    expect(mod.auth).toBeDefined();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    include: ['tests/session-options.test.ts'],
+    include: ['tests/**/*.test.ts'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- read Firebase config from `NEXT_PUBLIC_FIREBASE_*` environment variables
- document required Firebase environment variables
- test Firebase init via env-based config and update Vitest to run all tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68958aab39d883308190d52caf339e27