### PR TITLE
Wire real diagrams and charts through InfoPage props

### DIFF
--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -1,11 +1,24 @@
 // app/history/page.tsx
-import { InfoPage } from "@/components/templates/InfoPage"; // Removed InteractiveChartPlaceholder from here
-import HistoryTimelineChart from "@/components/charts/HistoryTimelineChart"; // Import the new chart
+import { InfoPage } from "@/components/templates/InfoPage";
+import HistoryTimelineChart from "@/components/charts/HistoryTimelineChart";
 
-// PLACEHOLDER CONTENT - All content below must be populated from the "SystemVerilog and UVM Mastery Blueprint"
+// PLACEHOLDER CONTENT - Populate from the "SystemVerilog and UVM Mastery Blueprint"
 
 const HistoryPage = () => {
   const pageTitle = "History of SystemVerilog & UVM";
+
+  const timelineSection = (
+    <div key="history-timeline">
+      <h2 className="text-2xl font-semibold mt-6 mb-3">Interactive Timeline of SV & UVM Evolution</h2>
+      <p className="mb-4">
+        The following timeline visualizes the key milestones in the development of SystemVerilog and UVM. Hover over the data points to see more details about each event. The size of the circle can be indicative of the event's impact or scope.
+      </p>
+      <HistoryTimelineChart />
+      <p className="text-sm text-muted-foreground mt-2 text-center">
+        This chart illustrates the journey from early hardware description languages to the comprehensive verification methodologies used today.
+      </p>
+    </div>
+  );
 
   const pageContent = (
     <>
@@ -17,7 +30,7 @@ const HistoryPage = () => {
 
       <section>
         <h2 className="text-2xl font-semibold mt-6 mb-3">The Rise of SystemVerilog</h2>
-        <p>[Placeholder: Key milestones in SystemVerilog&apos;s development - Superlog, Accellera&apos;s role, IEEE standardization (e.g., IEEE 1800), from blueprint].</p>
+        <p>[Placeholder: Key milestones in SystemVerilog's development - Superlog, Accellera's role, IEEE standardization (e.g., IEEE 1800), from blueprint].</p>
         <p>[Placeholder: Major feature introductions over time - assertions, coverage, OOP, interfaces, randomization, C interface (DPI), from blueprint].</p>
       </section>
 
@@ -33,19 +46,6 @@ const HistoryPage = () => {
         <p>[Placeholder: Standardization of UVM (e.g., IEEE 1800.2) and its widespread adoption in the industry, from blueprint].</p>
       </section>
 
-      {/* Section for the chart */}
-      <section>
-        <h2 className="text-2xl font-semibold mt-6 mb-3">Interactive Timeline of SV & UVM Evolution</h2>
-        <p className="mb-4">
-          The following timeline visualizes the key milestones in the development of SystemVerilog and UVM.
-          Hover over the data points to see more details about each event. The size of the circle can be indicative of the event&apos;s impact or scope.
-        </p>
-        <HistoryTimelineChart />
-        <p className="text-sm text-muted-foreground mt-2 text-center">
-          This chart illustrates the journey from early hardware description languages to the comprehensive verification methodologies used today.
-        </p>
-      </section>
-
       <section>
         <h2 className="text-2xl font-semibold mt-6 mb-3">The Future Outlook</h2>
         <p>[Placeholder: Brief thoughts on the continued evolution of SystemVerilog, UVM, and hardware verification practices, if covered in the blueprint].</p>
@@ -54,10 +54,11 @@ const HistoryPage = () => {
   );
 
   return (
-    <InfoPage title={pageTitle}>
+    <InfoPage title={pageTitle} charts={[timelineSection]}>
       {pageContent}
     </InfoPage>
   );
 };
 
 export default HistoryPage;
+

--- a/src/app/practice/visualizations/assertion-builder/page.tsx
+++ b/src/app/practice/visualizations/assertion-builder/page.tsx
@@ -3,9 +3,7 @@ import { InfoPage } from '@/components/templates/InfoPage';
 
 const AssertionBuilderPage = () => {
   return (
-    <InfoPage title="SVA Assertion Builder">
-      <AssertionBuilder />
-    </InfoPage>
+    <InfoPage title="SVA Assertion Builder" diagrams={[<AssertionBuilder key="assertion" />]} />
   );
 };
 

--- a/src/app/practice/visualizations/concurrency/page.tsx
+++ b/src/app/practice/visualizations/concurrency/page.tsx
@@ -3,9 +3,7 @@ import { InfoPage } from '@/components/templates/InfoPage';
 
 const ConcurrencyVisualizerPage = () => {
   return (
-    <InfoPage title="Concurrency Visualizer">
-      <ConcurrencyVisualizer />
-    </InfoPage>
+    <InfoPage title="Concurrency Visualizer" diagrams={[<ConcurrencyVisualizer key="concurrency" />]} />
   );
 };
 

--- a/src/app/practice/visualizations/coverage-analyzer/page.tsx
+++ b/src/app/practice/visualizations/coverage-analyzer/page.tsx
@@ -3,9 +3,7 @@ import { InfoPage } from '@/components/templates/InfoPage';
 
 const CoverageAnalyzerPage = () => {
   return (
-    <InfoPage title="Coverage Analyzer">
-      <CoverageAnalyzer />
-    </InfoPage>
+    <InfoPage title="Coverage Analyzer" diagrams={[<CoverageAnalyzer key="coverage" />]} />
   );
 };
 

--- a/src/app/practice/visualizations/data-type-comparison/page.tsx
+++ b/src/app/practice/visualizations/data-type-comparison/page.tsx
@@ -3,9 +3,7 @@ import { InfoPage } from '@/components/templates/InfoPage';
 
 const DataTypeComparisonChartPage = () => {
   return (
-    <InfoPage title="Data Type Comparison Chart">
-      <DataTypeComparisonChart />
-    </InfoPage>
+    <InfoPage title="Data Type Comparison Chart" charts={[<DataTypeComparisonChart key="dt-chart" />]} />
   );
 };
 

--- a/src/app/practice/visualizations/interface-signal-flow/page.tsx
+++ b/src/app/practice/visualizations/interface-signal-flow/page.tsx
@@ -3,9 +3,7 @@ import { InfoPage } from '@/components/templates/InfoPage';
 
 const InterfaceSignalFlowPage = () => {
   return (
-    <InfoPage title="Interface Signal Flow">
-      <InterfaceSignalFlow />
-    </InfoPage>
+    <InfoPage title="Interface Signal Flow" diagrams={[<InterfaceSignalFlow key="if-flow" />]} />
   );
 };
 

--- a/src/app/practice/visualizations/procedural-blocks/page.tsx
+++ b/src/app/practice/visualizations/procedural-blocks/page.tsx
@@ -3,9 +3,7 @@ import { InfoPage } from '@/components/templates/InfoPage';
 
 const ProceduralBlocksPage = () => {
   return (
-    <InfoPage title="Procedural Blocks Simulator">
-      <ProceduralBlocksSimulator />
-    </InfoPage>
+    <InfoPage title="Procedural Blocks Simulator" diagrams={[<ProceduralBlocksSimulator key="proc-blocks" />]} />
   );
 };
 

--- a/src/app/practice/visualizations/randomization-explorer/page.tsx
+++ b/src/app/practice/visualizations/randomization-explorer/page.tsx
@@ -3,9 +3,7 @@ import { InfoPage } from '@/components/templates/InfoPage';
 
 const RandomizationExplorerPage = () => {
   return (
-    <InfoPage title="Randomization Explorer">
-      <RandomizationExplorer />
-    </InfoPage>
+    <InfoPage title="Randomization Explorer" diagrams={[<RandomizationExplorer key="rand-explorer" />]} />
   );
 };
 

--- a/src/app/practice/visualizations/state-machine-designer/page.tsx
+++ b/src/app/practice/visualizations/state-machine-designer/page.tsx
@@ -3,9 +3,7 @@ import { InfoPage } from '@/components/templates/InfoPage';
 
 const StateMachineDesignerPage = () => {
   return (
-    <InfoPage title="State Machine Designer">
-      <StateMachineDesigner />
-    </InfoPage>
+    <InfoPage title="State Machine Designer" diagrams={[<StateMachineDesigner key="state-machine" />]} />
   );
 };
 

--- a/src/app/practice/visualizations/systemverilog-data-types/page.tsx
+++ b/src/app/practice/visualizations/systemverilog-data-types/page.tsx
@@ -3,9 +3,7 @@ import { InfoPage } from '@/components/templates/InfoPage';
 
 const SystemVerilogDataTypesPage = () => {
   return (
-    <InfoPage title="SystemVerilog Data Types Visualization">
-      <SystemVerilogDataTypesAnimation />
-    </InfoPage>
+    <InfoPage title="SystemVerilog Data Types Visualization" diagrams={[<SystemVerilogDataTypesAnimation key="sv-data" />]} />
   );
 };
 

--- a/src/app/practice/visualizations/uvm-architecture/page.tsx
+++ b/src/app/practice/visualizations/uvm-architecture/page.tsx
@@ -3,9 +3,7 @@ import { InfoPage } from '@/components/templates/InfoPage';
 
 const UvmArchitecturePage = () => {
   return (
-    <InfoPage title="Interactive UVM Architecture">
-      <InteractiveUvmArchitectureDiagram />
-    </InfoPage>
+    <InfoPage title="Interactive UVM Architecture" diagrams={[<InteractiveUvmArchitectureDiagram key="uvm-arch" />]} />
   );
 };
 

--- a/src/app/practice/visualizations/uvm-component-relationships/page.tsx
+++ b/src/app/practice/visualizations/uvm-component-relationships/page.tsx
@@ -3,9 +3,7 @@ import { InfoPage } from '@/components/templates/InfoPage';
 
 const UvmComponentRelationshipVisualizerPage = () => {
   return (
-    <InfoPage title="UVM Component Relationships">
-      <UvmComponentRelationshipVisualizer />
-    </InfoPage>
+    <InfoPage title="UVM Component Relationships" diagrams={[<UvmComponentRelationshipVisualizer key="uvm-comp-rel" />]} />
   );
 };
 

--- a/src/app/practice/visualizations/uvm-phasing/page.tsx
+++ b/src/app/practice/visualizations/uvm-phasing/page.tsx
@@ -3,9 +3,7 @@ import { InfoPage } from '@/components/templates/InfoPage';
 
 const UvmPhasingDiagramPage = () => {
   return (
-    <InfoPage title="UVM Phasing Diagram">
-      <UvmPhasingDiagram />
-    </InfoPage>
+    <InfoPage title="UVM Phasing Diagram" diagrams={[<UvmPhasingDiagram key="uvm-phasing" />]} />
   );
 };
 

--- a/src/components/templates/InfoPage.tsx
+++ b/src/components/templates/InfoPage.tsx
@@ -23,7 +23,7 @@ const DiagramPlaceholder = ({ title = "Diagram" }: { title?: string }) => (
 interface InfoPageProps {
   title?: string;
   description?: string;
-  children: ReactNode; // Main content of the page
+  children?: ReactNode; // Main content of the page
   // Optional slots for specific types of content
   charts?: ReactNode[];
   diagrams?: ReactNode[];
@@ -49,9 +49,11 @@ export const InfoPage: React.FC<InfoPageProps> = ({
             </header>
           )}
 
-          <section className="mb-8">
-            {children}
-          </section>
+          {children && (
+            <section className="mb-8">
+              {children}
+            </section>
+          )}
 
           {charts && charts.length > 0 && (
             <section className="mb-8">
@@ -59,8 +61,6 @@ export const InfoPage: React.FC<InfoPageProps> = ({
               {charts.map((chart, index) => (
                 <div key={`chart-${index}`}>{chart}</div>
               ))}
-              {/* Example of using the placeholder directly */}
-              {/* <InteractiveChartPlaceholder /> */}
             </section>
           )}
 
@@ -70,8 +70,6 @@ export const InfoPage: React.FC<InfoPageProps> = ({
               {diagrams.map((diagram, index) => (
                 <div key={`diagram-${index}`}>{diagram}</div>
               ))}
-              {/* Example of using the placeholder directly */}
-              {/* <DiagramPlaceholder /> */}
             </section>
           )}
         </article>


### PR DESCRIPTION
## Summary
- Allow `InfoPage` to render optional content and accept real chart and diagram components
- Pass `DataTypeComparisonChart`, `UvmPhasingDiagram`, and other visuals through `charts`/`diagrams` props across practice pages
- Showcase timeline chart on the history page via `charts` prop

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68958aae254883308815430acddf9ff0