### PR TITLE
feat: expand SystemVerilog tokenization and tests

### DIFF
--- a/tests/components/SystemVerilogLanguage.test.ts
+++ b/tests/components/SystemVerilogLanguage.test.ts
@@ -1,0 +1,36 @@
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
+import { registerSystemVerilogLanguage } from '@/components/ui/InteractiveCode';
+
+// jsdom does not implement matchMedia which Monaco expects.
+// Provide a minimal stub for the tests.
+beforeAll(() => {
+  if (!window.matchMedia) {
+    // @ts-ignore
+    window.matchMedia = () => ({
+      matches: false,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    });
+  }
+});
+
+describe('SystemVerilog language registration', () => {
+  it('tokenizes modules, classes and comments', () => {
+    registerSystemVerilogLanguage(monaco);
+
+    const code = `// A simple module\nmodule m;\n  class C;\n  endclass\nendmodule`;
+    const tokens = monaco.editor.tokenize(code, 'systemverilog');
+
+    // first line should be a comment
+    expect(tokens[0][0].type).toContain('comment');
+
+    // second line should contain a module keyword
+    expect(tokens[1].some(t => t.type.includes('keyword'))).toBe(true);
+
+    // third line should contain a class keyword
+    expect(tokens[2].some(t => t.type.includes('keyword'))).toBe(true);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    include: ['tests/session-options.test.ts'],
+    include: ['tests/**/*.test.ts?(x)'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- add Monarch-based SystemVerilog language registration with support for numbers, strings, macros and comments
- broaden Vitest config to pick up component tests
- add unit test asserting tokenization of modules, classes and comments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68958aaf94088330bfd4c830d8ef8485