### PR TITLE
Add topic-based flashcard decks and validation script

### DIFF
--- a/content/curriculum/T1_Foundational/F1_Why_Verification/index.mdx
+++ b/content/curriculum/T1_Foundational/F1_Why_Verification/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: "F1: Why Verification?"
 description: "An introduction to the world of hardware verification."
+flashcards: "F1_Why_Verification"
 ---
 
 import { Quiz, InteractiveCode } from '@/components/ui';

--- a/content/curriculum/T1_Foundational/F2_Data_Types/index.mdx
+++ b/content/curriculum/T1_Foundational/F2_Data_Types/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: "F2: SystemVerilog Data Types"
 description: "Understand SystemVerilog data types: the crucial difference between 2-state (bit, int) and 4-state (logic, wire, reg) types, and their application in modeling hardware signals and building verification testbenches."
+flashcards: "F2_Data_Types"
 ---
 
 import { Quiz, InteractiveCode } from '@/components/ui';

--- a/content/curriculum/T1_Foundational/F2_SystemVerilog_Primer/index.mdx
+++ b/content/curriculum/T1_Foundational/F2_SystemVerilog_Primer/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Module F-2: Digital Logic & HDL Primer'
 description: 'A crash course in the essential digital logic and HDL concepts for verification.'
+flashcards: 'F2_HDL_Primer'
 ---
 
 import { Quiz, InteractiveCode } from '@/components/ui';

--- a/content/curriculum/T1_Foundational/F3_Procedural_Constructs/index.mdx
+++ b/content/curriculum/T1_Foundational/F3_Procedural_Constructs/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: "F3: Procedural Constructs"
 description: "Understanding the building blocks of SystemVerilog code."
+flashcards: "F3_Procedural_Constructs"
 ---
 
 import { Quiz, InteractiveCode } from '@/components/ui';

--- a/content/curriculum/T1_Foundational/F4_RTL_and_Testbench_Constructs/index.mdx
+++ b/content/curriculum/T1_Foundational/F4_RTL_and_Testbench_Constructs/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: "F4: RTL and Testbench Constructs"
 description: "Key constructs for design and verification."
+flashcards: "F4_RTL_and_Testbench_Constructs"
 ---
 
 import { Quiz, InteractiveCode } from '@/components/ui';

--- a/content/flashcards/F1_Why_Verification.json
+++ b/content/flashcards/F1_Why_Verification.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "f1-1",
+    "question": "Why is verification essential before manufacturing a chip?",
+    "answer": "It detects design flaws early, avoiding costly fixes after fabrication."
+  },
+  {
+    "id": "f1-2",
+    "question": "What does verification compare a design against?",
+    "answer": "Its specification."
+  },
+  {
+    "id": "f1-3",
+    "question": "In the skyscraper analogy, what does the blueprint represent?",
+    "answer": "The design specification."
+  }
+]

--- a/content/flashcards/F2_Data_Types.json
+++ b/content/flashcards/F2_Data_Types.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "f2dt-1",
+    "question": "What are the four values of a 4-state logic type in SystemVerilog?",
+    "answer": "0, 1, X (unknown), Z (high-impedance)"
+  },
+  {
+    "id": "f2dt-2",
+    "question": "Which SystemVerilog type should be used for 2-state logic?",
+    "answer": "bit"
+  },
+  {
+    "id": "f2dt-3",
+    "question": "Name a composite data type used to bundle different fields together.",
+    "answer": "struct"
+  }
+]

--- a/content/flashcards/F3_Procedural_Constructs.json
+++ b/content/flashcards/F3_Procedural_Constructs.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "f3pc-1",
+    "question": "Which statement is used for conditional execution in SystemVerilog?",
+    "answer": "if-else"
+  },
+  {
+    "id": "f3pc-2",
+    "question": "What loop repeats a block of code for a fixed number of iterations?",
+    "answer": "for loop"
+  },
+  {
+    "id": "f3pc-3",
+    "question": "Which SystemVerilog keyword declares a task that can consume simulation time?",
+    "answer": "task"
+  }
+]

--- a/content/flashcards/F4_RTL_and_Testbench_Constructs.json
+++ b/content/flashcards/F4_RTL_and_Testbench_Constructs.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "f4rt-1",
+    "question": "Which always block is intended for combinational logic?",
+    "answer": "always_comb"
+  },
+  {
+    "id": "f4rt-2",
+    "question": "What construct allows grouping related declarations into a namespace?",
+    "answer": "package"
+  },
+  {
+    "id": "f4rt-3",
+    "question": "Which SystemVerilog feature connects a testbench to design signals with timing control?",
+    "answer": "clocking block"
+  }
+]

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run",
     "test:e2e": "next build && SESSION_SECRET=dummy_secret_for_testing_purposes npx playwright test",
     "crosslink": "node scripts/crosslink.cjs",
+    "validate:flashcards": "node scripts/validate-flashcards.cjs",
     "clean-and-run": "rm -rf .next && rm -rf node_modules && npm install && npm run dev"
   },
   "dependencies": {

--- a/scripts/validate-flashcards.cjs
+++ b/scripts/validate-flashcards.cjs
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+
+const dir = path.join(__dirname, '..', 'content', 'flashcards');
+
+const files = fs.readdirSync(dir).filter(f => f.endsWith('.json'));
+const globalIds = new Set();
+let hasError = false;
+
+for (const file of files) {
+  const filePath = path.join(dir, file);
+  const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  const ids = new Set();
+  data.forEach((card, idx) => {
+    if (!card.id || !card.question || !card.answer) {
+      console.error(`${file} card at index ${idx} has empty fields`);
+      hasError = true;
+    }
+    if (ids.has(card.id)) {
+      console.error(`${file} has duplicate id ${card.id}`);
+      hasError = true;
+    }
+    if (globalIds.has(card.id)) {
+      console.error(`Duplicate id across files: ${card.id} in ${file}`);
+      hasError = true;
+    }
+    ids.add(card.id);
+    globalIds.add(card.id);
+  });
+}
+
+if (hasError) {
+  process.exit(1);
+} else {
+  console.log('All flashcard files are valid');
+}

--- a/src/app/curriculum/[...slug]/page.tsx
+++ b/src/app/curriculum/[...slug]/page.tsx
@@ -18,6 +18,8 @@ import { DiagramPlaceholder, InteractiveChartPlaceholder } from '@/components/te
 import { Alert } from '@/components/ui/Alert';
 import dynamic from 'next/dynamic';
 import ConceptLink from '@/components/knowledge/ConceptLink';
+import matter from 'gray-matter';
+import FlashcardWidget from '@/components/widgets/FlashcardWidget';
 
 const AnimatedUvmSequenceDriverHandshakeDiagram = dynamic(() => import('@/components/diagrams/AnimatedUvmSequenceDriverHandshakeDiagram').then(mod => mod.AnimatedUvmSequenceDriverHandshakeDiagram));
 const DataTypeComparisonChart = dynamic(() => import('@/components/charts/DataTypeComparisonChart'));
@@ -80,8 +82,12 @@ export default async function CurriculumTopicPage({ params }: CurriculumTopicPag
     ...slug
   ) + '.mdx';
   let mdxContent;
+  let frontmatter: Record<string, any> = {};
   try {
-    mdxContent = await fs.readFile(mdxPath, 'utf8');
+    const file = await fs.readFile(mdxPath, 'utf8');
+    const parsed = matter(file);
+    mdxContent = parsed.content;
+    frontmatter = parsed.data;
   } catch (error) {
     notFound();
   }
@@ -99,6 +105,7 @@ export default async function CurriculumTopicPage({ params }: CurriculumTopicPag
       <article className="prose prose-invert max-w-none">
         <MDXRemote source={processedContent} components={components} />
       </article>
+      {frontmatter.flashcards && <FlashcardWidget deckId={frontmatter.flashcards} />}
       <FeynmanPromptWidget conceptTitle={topic.title} />
 
       {/* Navigation Footer */}

--- a/src/lib/flashcard-decks.ts
+++ b/src/lib/flashcard-decks.ts
@@ -1,0 +1,21 @@
+import F1_Why_Verification from '../../content/flashcards/F1_Why_Verification.json';
+import F2_Data_Types from '../../content/flashcards/F2_Data_Types.json';
+import F3_Procedural_Constructs from '../../content/flashcards/F3_Procedural_Constructs.json';
+import F4_RTL_and_Testbench_Constructs from '../../content/flashcards/F4_RTL_and_Testbench_Constructs.json';
+import F2_HDL_Primer from '../../content/flashcards/F2_HDL_Primer.json';
+
+export interface RawFlashcard {
+  id: string;
+  question: string;
+  answer: string;
+}
+
+export const flashcardDecks: Record<string, RawFlashcard[]> = {
+  F1_Why_Verification,
+  F2_Data_Types,
+  F3_Procedural_Constructs,
+  F4_RTL_and_Testbench_Constructs,
+  F2_HDL_Primer,
+};
+
+export default flashcardDecks;


### PR DESCRIPTION
## Summary
- Create flashcard decks for foundational modules (F1–F4) and map them for use
- Load flashcards by topic via frontmatter-driven `FlashcardWidget`
- Add script to validate flashcard JSON files and expose via npm script

## Testing
- `node scripts/validate-flashcards.cjs`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68958ab1c45883308ca28d99a2a95ef9