### PR TITLE
Refactor agent validation to surface warnings

### DIFF
--- a/src/components/exercises/UvmAgentBuilderExercise.tsx
+++ b/src/components/exercises/UvmAgentBuilderExercise.tsx
@@ -122,7 +122,9 @@ const UvmAgentBuilderExercise: React.FC = () => {
   const [availableComponents, setAvailableComponents] = useState<Item[]>(initialComponents);
   const [agentComponents, setAgentComponents] = useState<Item[]>([]);
   const [activeId, setActiveId] = useState<string | null>(null);
-  const [feedback, setFeedback] = useState<{ score: number; passed: boolean } | null>(null);
+  const [feedback, setFeedback] = useState<
+    { score: number; passed: boolean; warnings: string[] } | null
+  >(null);
 
 
 
@@ -192,28 +194,16 @@ const UvmAgentBuilderExercise: React.FC = () => {
   }
 
   const activeItem = getActiveItem();
-  const requiredIds = ['sequencer', 'driver', 'monitor'];
 
   const checkAgent = () => {
-    const correct = requiredIds.filter(id => agentComponents.some(item => item.id === id)).length;
-    const score = Math.round((correct / requiredIds.length) * 100);
-    setFeedback({ score, passed: score === 100 });
+    const { warnings, score } = checkAgentComponents(agentComponents);
+    setFeedback({ score, passed: score === 100, warnings });
   };
 
   const handleRetry = () => {
     setAvailableComponents(initialComponents);
     setAgentComponents([]);
     setFeedback(null);
-  };
-
-  const handleValidate = () => {
-    const { warnings, score } = checkAgentComponents(agentComponents);
-    setScore(score);
-    if (warnings.length === 0) {
-      setFeedback('Agent correctly built!');
-    } else {
-      setFeedback(warnings.join(' '));
-    }
   };
 
   return (
@@ -275,6 +265,13 @@ const UvmAgentBuilderExercise: React.FC = () => {
       {feedback && (
         <div className="mt-4 text-center">
           <p>Score: {feedback.score}%</p>
+          {feedback.warnings.length > 0 && (
+            <div className="text-yellow-500">
+              {feedback.warnings.map((w, i) => (
+                <p key={i}>{w}</p>
+              ))}
+            </div>
+          )}
           <p className={feedback.passed ? 'text-green-500' : 'text-red-500'}>
             {feedback.passed ? 'Pass' : 'Fail'}
           </p>

--- a/tests/components/UvmAgentBuilderExercise.test.ts
+++ b/tests/components/UvmAgentBuilderExercise.test.ts
@@ -1,14 +1,18 @@
 import { describe, it, expect } from 'vitest';
-import { checkAgentComponents, Item } from '@/components/exercises/UvmAgentBuilderExercise';
+import {
+  checkAgentComponents,
+  Item,
+} from '@/components/exercises/UvmAgentBuilderExercise';
 
 describe('checkAgentComponents', () => {
-  it('warns when required components are missing', () => {
+  it('warns and lowers score when required components are missing', () => {
     const agent: Item[] = [{ id: 'sequencer', name: 'Sequencer' }];
     const result = checkAgentComponents(agent);
     expect(result.warnings).toContain('Missing components: Driver, Monitor');
+    expect(result.score).toBe(33);
   });
 
-  it('warns when components are out of order', () => {
+  it('warns and lowers score when components are out of order', () => {
     const agent: Item[] = [
       { id: 'driver', name: 'Driver' },
       { id: 'sequencer', name: 'Sequencer' },
@@ -16,5 +20,17 @@ describe('checkAgentComponents', () => {
     ];
     const result = checkAgentComponents(agent);
     expect(result.warnings).toContain('Components are not in the correct order.');
+    expect(result.score).toBe(33);
+  });
+
+  it('returns full score with no warnings when agent is correct', () => {
+    const agent: Item[] = [
+      { id: 'sequencer', name: 'Sequencer' },
+      { id: 'driver', name: 'Driver' },
+      { id: 'monitor', name: 'Monitor' },
+    ];
+    const result = checkAgentComponents(agent);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.score).toBe(100);
   });
 });


### PR DESCRIPTION
## Summary
- Integrate `checkAgentComponents` into Check Agent flow
- Show warning messages alongside computed score
- Test validation warnings and scoring for missing, out-of-order, and correct agents

## Testing
- `npm test` *(fails: Unable to find an element with the text: /correct order/i, TypeError: Cannot read properties of null (reading 'signal'))*
- `npx vitest run tests/components/UvmAgentBuilderExercise.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689594bedc688330aac5ab759e2dffa9