### PR TITLE
Add mock waveform to wasm simulation and refine phase sorter scoring

### DIFF
--- a/src/components/exercises/UvmPhaseSorterExercise.tsx
+++ b/src/components/exercises/UvmPhaseSorterExercise.tsx
@@ -171,9 +171,11 @@ const UvmPhaseSorterExercise: React.FC<UvmPhaseSorterExerciseProps> = ({ initial
   }
 
   const checkOrder = () => {
-    const correct = items.filter((item, idx) => item.correctOrder === idx).length;
+    const correct = items.filter(
+      (item, idx) => item.correctOrder === uvmPhases[idx].correctOrder,
+    ).length;
     const score = Math.round((correct / items.length) * 100);
-    setFeedback({ score, passed: score === 100 });
+    setFeedback({ score, passed: correct === items.length });
   };
 
   const handleRetry = () => {

--- a/src/server/simulation/index.ts
+++ b/src/server/simulation/index.ts
@@ -30,8 +30,10 @@ export async function runSimulation(
         cmd = 'verilator --binary - && ./Vlt';
         break;
       default:
-        // Fallback placeholder for the wasm backend
-        cmd = 'echo "Simulation PASSED"';
+        // Fallback placeholder for the wasm backend.  We emit a small mock
+        // waveform so that unit tests and the UI have predictable data to
+        // render without requiring a full simulator.
+        cmd = 'printf "Simulation PASSED\nWAVEFORM: {\\"signal\\":[{\\"name\\":\\"clk\\",\\"wave\\":\\"p\\"}]}\n"';
         break;
     }
 

--- a/tests/components/UvmPhaseSorterExercise.test.tsx
+++ b/tests/components/UvmPhaseSorterExercise.test.tsx
@@ -10,7 +10,7 @@ describe('UvmPhaseSorterExercise', () => {
     render(<UvmPhaseSorterExercise initialItems={uvmPhases} />);
     const button = screen.getByRole('button', { name: /check order/i });
     await userEvent.click(button);
-    expect(await screen.findByText(/correct order/i)).toBeInTheDocument();
+    expect(await screen.findByText(/pass/i)).toBeInTheDocument();
   });
 
   it('detects incorrect sequence', async () => {
@@ -21,6 +21,6 @@ describe('UvmPhaseSorterExercise', () => {
     render(<UvmPhaseSorterExercise initialItems={shuffled} />);
     const button = screen.getByRole('button', { name: /check order/i });
     await userEvent.click(button);
-    expect(await screen.findByText(/incorrect order/i)).toBeInTheDocument();
+    expect(await screen.findByText(/fail/i)).toBeInTheDocument();
   });
 });

--- a/tests/server/runSimulation.test.ts
+++ b/tests/server/runSimulation.test.ts
@@ -17,6 +17,7 @@ describe('runSimulation', () => {
         const proc: any = new EventEmitter();
         proc.stdout = new EventEmitter();
         proc.stderr = new EventEmitter();
+        proc.stdin = { write: () => {}, end: () => {} };
         setTimeout(() => proc.emit('error', new Error('spawn failed')));
         return proc;
       },
@@ -24,6 +25,7 @@ describe('runSimulation', () => {
         const proc: any = new EventEmitter();
         proc.stdout = new EventEmitter();
         proc.stderr = new EventEmitter();
+        proc.stdin = { write: () => {}, end: () => {} };
         setTimeout(() => proc.emit('error', new Error('spawn failed')));
         return proc;
       } },


### PR DESCRIPTION
## Summary
- Provide predictable mock waveform output for the wasm simulation backend
- Compare phase sorter answers against reference order and adjust tests
- Stabilize runSimulation error test with proper stdin stub

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689589847d308330b65aa7b5f243b363