### PR TITLE
test: add e2e coverage for home links and hero animation

### DIFF
--- a/tests/e2e/ai-assistant-animation.spec.ts
+++ b/tests/e2e/ai-assistant-animation.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+
+test('AI assistant shows loading spinner when sending message', async ({ page }) => {
+  await page.route('**/api/ai/chat', async route => {
+    await new Promise(r => setTimeout(r, 500));
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ reply: 'hi there' })
+    });
+  });
+  await page.goto('/');
+  await page.getByLabel('Open AI Assistant').click();
+  const input = page.getByPlaceholder(/ask about systemverilog, uvm/i);
+  await input.fill('hello');
+  await page.getByLabel('Send message').click();
+  const spinner = page.locator('.animate-spin');
+  await expect(spinner).toBeVisible();
+  await expect(spinner).toBeHidden();
+  await expect(page.getByText('hi there')).toBeVisible();
+});

--- a/tests/e2e/hero-animation.spec.ts
+++ b/tests/e2e/hero-animation.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test';
+
+// The hero tagline on the home page rotates through multiple messages.
+// Verify that the text changes over time, demonstrating the animation.
+test('hero tagline cycles through messages', async ({ page }) => {
+  await page.goto('/');
+  const tagline = page.locator('section').locator('p').first();
+  const initialText = await tagline.textContent();
+  await page.waitForTimeout(6000); // wait for animation interval (5s)
+  await expect(tagline).not.toHaveText(initialText || '');
+});

--- a/tests/e2e/home-links.spec.ts
+++ b/tests/e2e/home-links.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+
+// Ensure that each internal link on the home page is reachable
+// and supports navigating back to the starting page.
+test('home page internal links are navigable and support back navigation', async ({ page }) => {
+  await page.goto('/');
+  const homeUrl = page.url();
+
+  const links = await page.$$eval('a[href^="/"]:not([href^="//"])', anchors => {
+    const set = new Set<string>();
+    anchors.forEach(a => {
+      const href = a.getAttribute('href');
+      if (href && !href.startsWith('#')) {
+        set.add(href);
+      }
+    });
+    return Array.from(set);
+  });
+
+  for (const href of links) {
+    await test.step(`checking ${href}`, async () => {
+      const response = await page.goto(href);
+      expect(response?.status()).toBeLessThan(400);
+      await page.goBack();
+      await expect(page).toHaveURL(homeUrl);
+    });
+  }
+});

--- a/tests/e2e/visualizations.spec.ts
+++ b/tests/e2e/visualizations.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Charts and visualizations', () => {
+  test('data type comparison chart renders', async ({ page }) => {
+    await page.goto('/practice/visualizations/data-type-comparison');
+    const svg = page.locator('svg');
+    await expect(svg).toBeVisible();
+    const barCount = await page.locator('svg rect').count();
+    expect(barCount).toBeGreaterThan(0);
+  });
+
+  test('history timeline chart renders', async ({ page }) => {
+    await page.goto('/history');
+    const svg = page.locator('svg');
+    await expect(svg).toBeVisible();
+    const pointCount = await page.locator('svg circle').count();
+    expect(pointCount).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add Playwright test ensuring all internal links on home page resolve without errors and support back navigation
- add animation test confirming hero tagline rotates through messages
- add tests verifying AI assistant spinner appears during chat requests and Recharts visualizations render

## Testing
- `npm test`
- `SESSION_SECRET=dummy_secret_for_testing_purposes npx playwright test` *(fails: host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68965c4bcb648330bd8a66d4f910c85a