### PR TITLE
Add coverage sampling and synchronization content

### DIFF
--- a/content/curriculum/T2_Intermediate/I-SV-3_Functional_Coverage/coverage-options.mdx
+++ b/content/curriculum/T2_Intermediate/I-SV-3_Functional_Coverage/coverage-options.mdx
@@ -1,8 +1,9 @@
 import { InfoPage } from "@/components/templates/InfoPage";
+import { Quiz, InteractiveCode } from "@/components/ui";
 
 export const metadata = {
   title: "Coverage Options and Sampling | Advanced UVM Techniques & Strategy",
-  description: "...",
+  description: "Learn how covergroup options influence when and how data is sampled.",
 };
 
 <InfoPage
@@ -10,8 +11,75 @@ export const metadata = {
   uvm_concept_tags={["coverage options", "sampling"]}
 >
 
-  ## Coverage Options and Sampling
+  ## Level 1: The Big Idea
 
-  This section is under construction. Please check back later.
+  Coverage points only help if they sample at the right moment. SystemVerilog covergroups provide **options** to control when sampling happens and how results are reported.
+
+  **The Analogy:** A covergroup is like a camera. Sampling options decide when the shutter clicks and how the photos are cataloged.
+
+  ## Level 2: Practical Usage
+
+  ### Automatic vs. Manual Sampling
+
+  -   Define an event to sample automatically: `covergroup cg @(posedge clk);`
+  -   Call `cg.sample()` manually when your monitor observes a transaction. See the [analysis components](/curriculum/uvm-building/essentials/analysis-components) page for how monitors publish transactions through analysis ports.
+
+  ### Useful Options
+
+  -   `option.per_instance`: track coverage separately for each instance.
+  -   `option.goal`: set the percentage goal that determines completion.
+  -   `option.comment`: attach notes such as a V-Plan ID.
+
+  <InteractiveCode>
+  ```systemverilog
+  covergroup cg_pkt @(posedge clk);
+    option.per_instance = 1;
+    option.goal = 90;
+    option.comment = "VP-3.1";
+    cp_kind: coverpoint pkt.kind;
+  endgroup
+
+  initial begin
+    cg_pkt cov = new;
+    // Manual sampling example
+    @(posedge clk);
+    cov.sample();
+  end
+  ```
+  </InteractiveCode>
+
+  ## Level 3: Expert Insights
+
+  **Gating and Conditional Sampling:** Use `iff` to sample only when a condition is true, preventing meaningless hits.
+
+  **Per-Instance vs. Merge:** Per-instance coverage isolates under-tested blocks, while merged coverage gives an overall view.
+
+  **Coverage Closure Loop:** Coverage reports feed back into constraint tweaks. Review [Constrained Randomization](/curriculum/T2_Intermediate/I-SV-2_Constrained_Randomization) to see how stimulus can be adjusted to hit missing bins.
+
+  ## Quiz
+
+  <Quiz questions={[
+    {
+      question: "Which option allows each instance of a covergroup to maintain its own coverage results?",
+      answers: [
+        { text: "`option.per_instance`", correct: true },
+        { text: "`option.goal`", correct: false },
+        { text: "`option.weight`", correct: false },
+        { text: "`option.comment`", correct: false }
+      ],
+      explanation: "`option.per_instance` ensures coverage is tracked separately for each covergroup instance."
+    },
+    {
+      question: "How do you manually trigger coverage sampling?",
+      answers: [
+        { text: "Assigning to a coverpoint variable", correct: false },
+        { text: "Calling the `sample()` method", correct: true },
+        { text: "Using `option.goal`", correct: false },
+        { text: "Waiting on `@`", correct: false }
+      ],
+      explanation: "Calling the `sample()` method causes the covergroup to capture the current values."
+    }
+  ]} />
 
 </InfoPage>
+

--- a/content/curriculum/T2_Intermediate/I-SV-3_Functional_Coverage/events.mdx
+++ b/content/curriculum/T2_Intermediate/I-SV-3_Functional_Coverage/events.mdx
@@ -1,8 +1,9 @@
 import { InfoPage } from "@/components/templates/InfoPage";
+import { Quiz, InteractiveCode } from "@/components/ui";
 
 export const metadata = {
   title: "Events | Advanced SystemVerilog for Verification",
-  description: "...",
+  description: "Synchronize parallel processes with SystemVerilog events.",
 };
 
 <InfoPage
@@ -10,8 +11,69 @@ export const metadata = {
   sv_concept_tags={["events"]}
 >
 
-  ## Events
+  ## Level 1: The Big Idea
 
-  This section is under construction. Please check back later.
+  An **event** is a simple synchronization object. One process can signal an event, and another can wait for it. It's like ringing a doorbell and waiting for someone to answer.
+
+  ## Level 2: Practical Usage
+
+  ### Declaring and Triggering
+
+  -   Declare an event: `event done;`
+  -   Trigger it: `-> done;`
+  -   Wait for it: `@done;`
+
+  <InteractiveCode>
+  ```systemverilog
+  event start;
+
+  initial begin
+    // Stimulus thread
+    #10 -> start;      // trigger the event
+  end
+
+  initial begin
+    // Monitor thread
+    @start;             // wait for trigger
+    $display("Started at %0t", $time);
+  end
+  ```
+  </InteractiveCode>
+
+  Events often coordinate randomized stimulus or monitor actions. Review [Constrained Randomization](/curriculum/T2_Intermediate/I-SV-2_Constrained_Randomization) to see how events can trigger new random transactions.
+
+  ## Level 3: Expert Insights
+
+  **Multiple Triggers:** An event can be triggered repeatedly; waiting processes react to each trigger.
+
+  **`wait_order`:** Use `wait_order(e1, e2)` to ensure events occur in sequence.
+
+  **`uvm_event`:** UVM provides `uvm_event` with additional features like callbacks and history. See [analysis components](/curriculum/uvm-building/essentials/analysis-components) for how events can work alongside analysis ports.
+
+  ## Quiz
+
+  <Quiz questions={[
+    {
+      question: "Which statement waits for event `go` to be triggered?",
+      answers: [
+        { text: "`-> go;`", correct: false },
+        { text: "`@go;`", correct: true },
+        { text: "`wait(go);`", correct: false },
+        { text: "`disable go;`", correct: false }
+      ],
+      explanation: "`@go;` suspends the process until the event `go` is triggered."
+    },
+    {
+      question: "How do you trigger an event named `done`?",
+      answers: [
+        { text: "`@done;`", correct: false },
+        { text: "`-> done;`", correct: true },
+        { text: "`event done;`", correct: false },
+        { text: "`done.trigger();`", correct: false }
+      ],
+      explanation: "The `->` operator triggers a SystemVerilog event."
+    }
+  ]} />
 
 </InfoPage>
+

--- a/content/curriculum/T2_Intermediate/I-SV-3_Functional_Coverage/linking-coverage.mdx
+++ b/content/curriculum/T2_Intermediate/I-SV-3_Functional_Coverage/linking-coverage.mdx
@@ -1,8 +1,9 @@
 import { InfoPage } from "@/components/templates/InfoPage";
+import { Quiz, InteractiveCode } from "@/components/ui";
 
 export const metadata = {
   title: "Linking Coverage to the V-Plan | Advanced UVM Techniques & Strategy",
-  description: "...",
+  description: "Tie functional coverage points back to verification plan items.",
 };
 
 <InfoPage
@@ -10,8 +11,63 @@ export const metadata = {
   uvm_concept_tags={["coverage", "v-plan"]}
 >
 
-  ## Linking Coverage to the V-Plan
+  ## Level 1: Why Link Coverage?
 
-  This section is under construction. Please check back later.
+  A verification plan (V-Plan) lists the features the design must support. Linking **covergroups** to plan items proves that each requirement has been exercised in simulation.
+
+  **The Analogy:** Imagine a checklist for a road trip. Each time you visit a landmark, you tick it off. Coverage-to-V-Plan linkage is that checklist for verification.
+
+  ## Level 2: Practical Method
+
+  ### Tagging Covergroups
+
+  Use options to embed plan information:
+
+  <InteractiveCode>
+  ```systemverilog
+  covergroup cg_mode @(posedge clk);
+    option.comment = "VPLAN-5.2"; // link to plan item
+    cp_mode: coverpoint mode;
+  endgroup
+  ```
+  </InteractiveCode>
+
+  Coverage collectors often subscribe to monitor analysis ports. See [analysis components](/curriculum/uvm-building/essentials/analysis-components) for how transactions reach these covergroups.
+
+  Reports can then filter coverage by `option.comment`, giving traceability back to the V-Plan. When holes appear, adjust stimulus using [Constrained Randomization](/curriculum/T2_Intermediate/I-SV-2_Constrained_Randomization).
+
+  ## Level 3: Expert Insights
+
+  **Tool Integration:** Many tools export coverage databases (like UCDB) with plan IDs, enabling dashboards that show verification progress.
+
+  **Granularity:** Link coverpoints or bins to individual requirements for fine-grained tracking.
+
+  **Process:** Regular reviews of V-Plan-linked coverage ensure the plan remains accurate as the design evolves.
+
+  ## Quiz
+
+  <Quiz questions={[
+    {
+      question: "Why link coverage data to the V-Plan?",
+      answers: [
+        { text: "To speed up simulations", correct: false },
+        { text: "To prove each requirement has been exercised", correct: true },
+        { text: "To reduce code size", correct: false },
+        { text: "To enable automatic reset", correct: false }
+      ],
+      explanation: "Linking coverage to the plan demonstrates that every planned feature was verified."
+    },
+    {
+      question: "Which option can store a V-Plan reference inside a covergroup?",
+      answers: [
+        { text: "`option.per_instance`", correct: false },
+        { text: "`option.comment`", correct: true },
+        { text: "`option.goal`", correct: false },
+        { text: "`option.weight`", correct: false }
+      ],
+      explanation: "`option.comment` is often used to embed plan IDs or notes in coverage results."
+    }
+  ]} />
 
 </InfoPage>
+

--- a/content/curriculum/T2_Intermediate/I-SV-3_Functional_Coverage/mailboxes.mdx
+++ b/content/curriculum/T2_Intermediate/I-SV-3_Functional_Coverage/mailboxes.mdx
@@ -1,8 +1,9 @@
 import { InfoPage } from "@/components/templates/InfoPage";
+import { Quiz, InteractiveCode } from "@/components/ui";
 
 export const metadata = {
   title: "Mailboxes | Advanced SystemVerilog for Verification",
-  description: "...",
+  description: "Use mailboxes for thread-safe communication between processes.",
 };
 
 <InfoPage
@@ -10,8 +11,72 @@ export const metadata = {
   sv_concept_tags={["mailboxes"]}
 >
 
-  ## Mailboxes
+  ## Level 1: The Big Idea
 
-  This section is under construction. Please check back later.
+  A **mailbox** is a built-in message queue. One process `put`s an item into the mailbox while another `get`s it out. It's like dropping a letter into a box for someone else to pick up later.
+
+  ## Level 2: Practical Usage
+
+  ### Basic Operations
+
+  -   `put(item)`: place an item into the mailbox (blocks if full).
+  -   `get(item)`: remove an item (blocks if empty).
+  -   `try_get(item)` and `peek(item)`: non-blocking alternatives.
+
+  <InteractiveCode>
+  ```systemverilog
+  typedef struct {int id; bit [7:0] data;} packet;
+  mailbox #(packet) mbx = new(4); // depth of 4
+
+  initial begin
+    packet p;
+    p.id = 1;
+    p.data = $urandom;
+    mbx.put(p); // producer
+  end
+
+  initial begin
+    packet r;
+    mbx.get(r); // consumer waits here until item arrives
+    $display("Got packet %0d", r.id);
+  end
+  ```
+  </InteractiveCode>
+
+  Mailboxes often carry randomized transactions. For generating those transactions, see [Constrained Randomization](/curriculum/T2_Intermediate/I-SV-2_Constrained_Randomization).
+
+  ## Level 3: Expert Insights
+
+  **Bounded vs. Unbounded:** A mailbox without a size is unbounded and never blocks on `put`. Bounded mailboxes model limited buffers.
+
+  **Typed Mailboxes:** Parameterized mailboxes (`mailbox#(packet)`) catch type mismatches at compile time.
+
+  **Mailboxes vs. Analysis Ports:** Mailboxes connect one producer to one consumer. For broadcasting transactions to multiple subscribers, use [analysis ports](/curriculum/uvm-building/essentials/analysis-components).
+
+  ## Quiz
+
+  <Quiz questions={[
+    {
+      question: "What happens when `get()` is called on an empty mailbox?",
+      answers: [
+        { text: "It returns immediately with a default value", correct: false },
+        { text: "It blocks until an item is available", correct: true },
+        { text: "It deletes the mailbox", correct: false },
+        { text: "It throws a runtime error", correct: false }
+      ],
+      explanation: "`get()` blocks the calling process until data is present in the mailbox."
+    },
+    {
+      question: "How do you create a mailbox with a depth of 4 packets?",
+      answers: [
+        { text: "`mailbox mbx = new;`", correct: false },
+        { text: "`mailbox #(packet) mbx = new(4);`", correct: true },
+        { text: "`mailbox[4] mbx;`", correct: false },
+        { text: "`mailbox mbx[4];`", correct: false }
+      ],
+      explanation: "Passing a number to `new` sets the mailbox depth." 
+    }
+  ]} />
 
 </InfoPage>
+

--- a/content/curriculum/T2_Intermediate/I-SV-3_Functional_Coverage/semaphores.mdx
+++ b/content/curriculum/T2_Intermediate/I-SV-3_Functional_Coverage/semaphores.mdx
@@ -1,8 +1,9 @@
 import { InfoPage } from "@/components/templates/InfoPage";
+import { Quiz, InteractiveCode } from "@/components/ui";
 
 export const metadata = {
   title: "Semaphores | Advanced SystemVerilog for Verification",
-  description: "...",
+  description: "Control access to shared resources using semaphore keys.",
 };
 
 <InfoPage
@@ -10,8 +11,71 @@ export const metadata = {
   sv_concept_tags={["semaphores"]}
 >
 
-  ## Semaphores
+  ## Level 1: The Big Idea
 
-  This section is under construction. Please check back later.
+  A **semaphore** is like a set of keys. Processes must take a key (`get`) before using a shared resource and return it (`put`) when done. If no keys are available, the process waits.
+
+  ## Level 2: Practical Usage
+
+  ### Getting and Putting Keys
+
+  -   `semaphore sem = new(1);` creates a semaphore with one key.
+  -   `sem.get(1);` acquires a key (blocks if none are free).
+  -   `sem.put(1);` releases a key.
+  -   `sem.try_get(1);` attempts to get a key without blocking.
+
+  <InteractiveCode>
+  ```systemverilog
+  semaphore bus_sem = new(1);
+
+  task master(string name);
+    bus_sem.get(1);        // wait for access
+    $display("%s using bus at %0t", name, $time);
+    #10;
+    bus_sem.put(1);        // release
+  endtask
+
+  initial begin
+    fork
+      master("A");
+      master("B");
+    join
+  end
+  ```
+  </InteractiveCode>
+
+  ## Level 3: Expert Insights
+
+  **Resource Pools:** Use semaphores with more than one key to model pools like DMA channels or memory ports.
+
+  **Fairness:** Combining `try_get` with random delays can prevent starvation in heavily contended systems.
+
+  **Coordinating Random Stimulus:** When multiple threads generate randomized transactions, semaphores ensure only a safe number run concurrently. For more on stimulus generation, revisit [Constrained Randomization](/curriculum/T2_Intermediate/I-SV-2_Constrained_Randomization).
+
+  ## Quiz
+
+  <Quiz questions={[
+    {
+      question: "What happens if `sem.get(2)` is called when only one key is available?",
+      answers: [
+        { text: "The call blocks until two keys are available", correct: true },
+        { text: "One key is returned immediately", correct: false },
+        { text: "An error is thrown", correct: false },
+        { text: "The semaphore is reset", correct: false }
+      ],
+      explanation: "`get` waits until the requested number of keys can be obtained."
+    },
+    {
+      question: "Which method acquires a semaphore key without blocking?",
+      answers: [
+        { text: "`get`", correct: false },
+        { text: "`put`", correct: false },
+        { text: "`try_get`", correct: true },
+        { text: "`wait`", correct: false }
+      ],
+      explanation: "`try_get` attempts to get keys and returns immediately if none are available."
+    }
+  ]} />
 
 </InfoPage>
+


### PR DESCRIPTION
## Summary
- Flesh out coverage sampling options with examples and quiz
- Explain SystemVerilog events and linking coverage to the V-Plan
- Document mailboxes and semaphores with cross-links to analysis ports and randomization

## Testing
- `npm test`
- `npm run lint` *(fails: React hook rule violations)*
- `npm run type-check` *(fails: TS errors in components and tests)*

------
https://chatgpt.com/codex/tasks/task_e_6897f48f40208330b005412ecc1690df