### PR TITLE
docs: add uvm report server and root sections

### DIFF
--- a/content/curriculum/T2_Intermediate/I-UVM-2_Building_TB/uvm-report-server.mdx
+++ b/content/curriculum/T2_Intermediate/I-UVM-2_Building_TB/uvm-report-server.mdx
@@ -1,8 +1,10 @@
 import { InfoPage } from "@/components/templates/InfoPage";
+import { Quiz } from "@/components/ui";
+import { CodeBlock } from "@/components/ui/CodeBlock";
 
 export const metadata = {
   title: "UVM Report Server and Verbosity | The UVM Universe - Core Concepts",
-  description: "...",
+  description: "Centralized UVM message control and how to override it with a custom report handler.",
 };
 
 <InfoPage
@@ -10,8 +12,47 @@ export const metadata = {
   uvm_concept_tags={["report server", "verbosity"]}
 >
 
-  ## UVM Report Server and Verbosity
+  ## Level 1: The Testbench Newsroom
 
-  This section is under construction. Please check back later.
+  `uvm_report_server` collects every message in the testbench and decides how it is printed.  
+  Think of it as a newsroom editor that formats stories before publication.  
+  It matters because consistent reporting and verbosity control make debugging manageable.
+
+  ## Level 2: Custom Report Handler Example
+
+  You can replace a component's default `uvm_report_handler` to redirect messages or change formatting.
+
+  <CodeBlock language="systemverilog" code={`class file_report_handler extends uvm_report_handler;\n  int fd;\n  function new();\n    super.new();\n    fd = $fopen("run.log","w");\n  endfunction\n\n  virtual function void report(uvm_report_server server, uvm_report_message msg);\n    $fdisplay(fd,"%s: %s", msg.get_severity_name(), msg.get_msg());\n    super.report(server, msg); // keep normal processing\n  endfunction\nendclass\n\nclass my_env extends uvm_env;\n  `uvm_component_utils(my_env)\n  function void build_phase(uvm_phase phase);\n    super.build_phase(phase);\n    set_report_handler(new file_report_handler());\n  endfunction\nendclass\n`} />
+
+  ## Level 3: Expert Tips
+
+  - Replace the global server with `uvm_report_server::set_server()` when you need system-wide changes.  
+  - `uvm_report_catcher` is handy for filtering messages without writing a new handler.  
+  - Use `set_report_verbosity_level` or the `+UVM_VERBOSITY` command-line option to tune output volume.
+
+  ## Check Your Understanding
+
+  <Quiz questions={[
+    {
+      "question": "What is the primary role of `uvm_report_server`?",
+      "answers": [
+        { "text": "Scheduling phases", "correct": false },
+        { "text": "Formatting and routing UVM messages", "correct": true },
+        { "text": "Randomizing transactions", "correct": false },
+        { "text": "Configuring the factory", "correct": false }
+      ],
+      "explanation": "`uvm_report_server` centralizes message formatting and dispatch."
+    },
+    {
+      "question": "How can you replace a component's default reporting behavior?",
+      "answers": [
+        { "text": "Call `uvm_root::get()`", "correct": false },
+        { "text": "Extend `uvm_report_handler` and use `set_report_handler()`", "correct": true },
+        { "text": "Invoke `run_test()`", "correct": false },
+        { "text": "Change interface connections", "correct": false }
+      ],
+      "explanation": "Overriding the handler lets you customize how messages are processed."
+    }
+  ]} />
 
 </InfoPage>

--- a/content/curriculum/T2_Intermediate/I-UVM-2_Building_TB/uvm-root.mdx
+++ b/content/curriculum/T2_Intermediate/I-UVM-2_Building_TB/uvm-root.mdx
@@ -1,8 +1,10 @@
 import { InfoPage } from "@/components/templates/InfoPage";
+import { Quiz } from "@/components/ui";
+import { CodeBlock } from "@/components/ui/CodeBlock";
 
 export const metadata = {
   title: "uvm_root and Test Execution | The UVM Universe - Core Concepts",
-  description: "...",
+  description: "The singleton that orchestrates UVM phases and launches tests.",
 };
 
 <InfoPage
@@ -10,8 +12,48 @@ export const metadata = {
   uvm_concept_tags={["uvm_root", "test execution"]}
 >
 
-  ## uvm_root and Test Execution
+  ## Level 1: The Testbench Conductor
 
-  This section is under construction. Please check back later.
+  `uvm_root` is the one-and-only top-level component that coordinates all others.  
+  Imagine it as the conductor of an orchestra, ensuring every section plays in sync.  
+  Without `uvm_root`, the phases and report settings would have no central authority.
+
+  ## Level 2: Running the Show
+
+  A top-level Verilog module calls `run_test` to start the UVM test.  
+  `uvm_root` builds the hierarchy, runs phases, and wraps up the simulation.
+
+  <CodeBlock language="systemverilog" code={`import uvm_pkg::*;\n`include "uvm_macros.svh"\n\nclass my_test extends uvm_test;\n  `uvm_component_utils(my_test)\n  function new(string name, uvm_component parent);\n    super.new(name,parent);\n  endfunction\nendclass\n\nmodule top;\n  initial begin\n    uvm_root::get().set_report_verbosity_level(UVM_LOW); // optional global setting\n    run_test("my_test");\n  end\nendmodule\n`} />
+
+  ## Level 3: Veteran Notes
+
+  - `uvm_root::get().print_topology()` is invaluable for debugging hierarchy issues.  
+  - Global timeouts can be set with `uvm_root::get().set_timeout(1ms, 0);`.  
+  - Command-line `+UVM_TESTNAME` overrides the test name without editing code.
+
+  ## Check Your Understanding
+
+  <Quiz questions={[
+    {
+      "question": "Which singleton orchestrates UVM phase execution?",
+      "answers": [
+        { "text": "`uvm_root`", "correct": true },
+        { "text": "`uvm_test`", "correct": false },
+        { "text": "`uvm_env`", "correct": false },
+        { "text": "`uvm_report_server`", "correct": false }
+      ],
+      "explanation": "`uvm_root` sits at the top of the component tree and controls phases."
+    },
+    {
+      "question": "Which statement starts a UVM test from a top-level module?",
+      "answers": [
+        { "text": "`uvm_root::get()`", "correct": false },
+        { "text": "`set_report_handler()`", "correct": false },
+        { "text": "`run_test(\"my_test\")`", "correct": true },
+        { "text": "`uvm_component_utils`", "correct": false }
+      ],
+      "explanation": "`run_test` tells `uvm_root` which test to build and execute."
+    }
+  ]} />
 
 </InfoPage>


### PR DESCRIPTION
## Summary
- Expand report server guide with Level 1–3 explanations, custom report handler example, and quiz
- Flesh out uvm_root page covering test execution, hierarchy tips, and quiz

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897f49386fc8330915e762784910957