### PR TITLE
docs: add config and resource db examples with quizzes

### DIFF
--- a/content/curriculum/T2_Intermediate/I-UVM-3_Sequences/uvm-config-db.mdx
+++ b/content/curriculum/T2_Intermediate/I-UVM-3_Sequences/uvm-config-db.mdx
@@ -1,8 +1,9 @@
 import { InfoPage } from "@/components/templates/InfoPage";
+import { Quiz } from "@/components/ui";
 
 export const metadata = {
   title: "uvm_config_db: set and get | The UVM Universe - Core Concepts",
-  description: "...",
+  description: "Use the UVM configuration database to pass settings down the hierarchy without tight coupling.",
 };
 
 <InfoPage
@@ -12,6 +13,68 @@ export const metadata = {
 
   ## uvm_config_db: set and get
 
-  This section is under construction. Please check back later.
+  The `uvm_config_db` allows higher-level components or the testbench top to
+  pass configuration data down the component hierarchy. A typical use is
+  sharing a virtual interface handle with a driver.
+
+  ### `uvm_config_db::set()`
+
+  ```systemverilog
+  // In a top-level module or the test
+  initial begin
+    uvm_config_db#(virtual alu_if)::set(null,
+                                        "uvm_test_top.env.agent.drv",
+                                        "vif", vif);
+  end
+  ```
+
+  ### `uvm_config_db::get()`
+
+  ```systemverilog
+  // Inside the driver's build_phase
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    if (!uvm_config_db#(virtual alu_if)::get(this, "", "vif", vif))
+      `uvm_fatal("NOVIF", "Virtual interface not set")
+  endfunction
+  ```
+
+  ### Practical Usage Patterns
+
+  - Set configuration values in the test or environment; retrieve them in
+    lower components during `build_phase`.
+  - Use wildcard paths (`"*"`, `"?"`) to apply a setting to multiple
+    components at once.
+  - Store configuration objects so many components can share the same
+    settings.
+  - Always check the return value of `get` and provide a meaningful error if
+    the field is missing.
+
+  ## Check Your Understanding
+
+  <Quiz questions={[
+    {
+      question: "Where is `uvm_config_db::set` typically called to pass a virtual interface handle?",
+      answers: [
+        { text: "In a lower-level driver", correct: false },
+        { text: "In the top-level module or test", correct: true },
+        { text: "Inside the sequence item", correct: false },
+        { text: "Only in the RTL", correct: false }
+      ],
+      explanation:
+        "The test or top-level module places the handle in the configuration database so lower components can retrieve it.",
+    },
+    {
+      question: "What should a component do if `uvm_config_db::get` returns 0?",
+      answers: [
+        { text: "Ignore the missing value", correct: false },
+        { text: "Fall back to a default or issue a fatal error", correct: true },
+        { text: "Call `get` again with a wildcard", correct: false },
+        { text: "Use `uvm_resource_db` instead", correct: false }
+      ],
+      explanation:
+        "Always handle a failed `get` call explicitly so configuration mistakes don't go unnoticed.",
+    },
+  ]} />
 
 </InfoPage>

--- a/content/curriculum/T2_Intermediate/I-UVM-3_Sequences/uvm-resource-db.mdx
+++ b/content/curriculum/T2_Intermediate/I-UVM-3_Sequences/uvm-resource-db.mdx
@@ -1,8 +1,9 @@
 import { InfoPage } from "@/components/templates/InfoPage";
+import { Quiz } from "@/components/ui";
 
 export const metadata = {
   title: "uvm_resource_db and Precedence | The UVM Universe - Core Concepts",
-  description: "...",
+  description: "Resolve configuration conflicts using the underlying resource database and precedence rules.",
 };
 
 <InfoPage
@@ -12,6 +13,60 @@ export const metadata = {
 
   ## uvm_resource_db and Precedence
 
-  This section is under construction. Please check back later.
+  `uvm_resource_db` is the lower-level database that powers
+  `uvm_config_db`. Each resource can have an associated *precedence*. When
+  multiple writers set the same resource, the value with the highest
+  precedence wins.
+
+  ### Example: Competing Resource Settings
+
+  ```systemverilog
+  // Two components set the same resource with different precedence values
+  uvm_resource_db#(int)::set("*", "timeout", 50, this, 50);   // default
+  uvm_resource_db#(int)::set("*", "timeout", 100, this, 100); // higher precedence
+
+  int timeout;
+  void'(uvm_resource_db#(int)::read_by_name("*", "timeout", timeout));
+  `uvm_info("RESOURCE", $sformatf("timeout=%0d", timeout), UVM_MEDIUM);
+  ```
+
+  The second `set` call uses a higher precedence (`100`), so the retrieved
+  value is `100` even though an earlier call provided `50`.
+
+  ### Practical Usage Patterns
+
+  - Use `uvm_resource_db` for advanced scenarios when `uvm_config_db` is too
+    restrictive.
+  - Provide default values with low precedence, then allow tests to override
+    them with higher precedence settings.
+  - Combine with `uvm_config_db` by accessing the underlying resource for
+    fine-grained control.
+
+  ## Check Your Understanding
+
+  <Quiz questions={[
+    {
+      question: "If two resources with the same name are set with different precedence, which value is returned?",
+      answers: [
+        { text: "The one set first", correct: false },
+        { text: "The one with the highest precedence", correct: true },
+        { text: "The one from the lowest scope", correct: false },
+        { text: "The database returns both values", correct: false }
+      ],
+      explanation:
+        "Precedence ensures that the resource with the highest value wins when duplicates exist.",
+    },
+    {
+      question: "When should you use `uvm_resource_db` directly instead of `uvm_config_db`?",
+      answers: [
+        { text: "Whenever you need a virtual interface", correct: false },
+        { text: "Only for very advanced or custom configuration mechanisms", correct: true },
+        { text: "It should replace `uvm_config_db` in all testbenches", correct: false },
+        { text: "To speed up compilation", correct: false }
+      ],
+      explanation:
+        "The resource database is typically used only when you require features like explicit precedence control or custom access patterns.",
+    },
+  ]} />
 
 </InfoPage>


### PR DESCRIPTION
## Summary
- explain uvm_config_db::set and ::get with practical usage tips
- show how uvm_resource_db precedence chooses the winning resource
- add quizzes to reinforce understanding of configuration and resources

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897f494fa288330b5bda85fc9dab066