### PR TITLE
Add phase domain, jumping, and synchronization docs with quiz

### DIFF
--- a/content/curriculum/T2_Intermediate/I-UVM-5_Phasing_and_Synchronization/domains-phase-jumping.mdx
+++ b/content/curriculum/T2_Intermediate/I-UVM-5_Phasing_and_Synchronization/domains-phase-jumping.mdx
@@ -1,4 +1,5 @@
 import { InfoPage } from "@/components/templates/InfoPage";
+import { InteractiveCode } from "@/components/ui";
 
 export const metadata = {
   title: "Domains and Phase Jumping | The UVM Universe - Core Concepts",
@@ -10,8 +11,45 @@ export const metadata = {
   uvm_concept_tags={["domains", "phase jumping"]}
 >
 
-  ## Domains and Phase Jumping
+  ## Phase Domains
 
-  This section is under construction. Please check back later.
+  Phases execute in a **domain**. The default *common* domain runs all components
+  through the standard phase sequence. You can create additional domains to run
+  a subset of components with their own phase schedule—for example, to keep a
+  configuration agent alive after the rest of the environment has stopped.
+
+  <InteractiveCode
+    language="systemverilog"
+    fileName="custom_domain_example.sv"
+    code={`class cfg_agent extends uvm_agent;
+  `uvm_component_utils(cfg_agent)
+  // ...
+endclass
+
+class my_env extends uvm_env;
+  `uvm_component_utils(my_env)
+  cfg_agent cfg;
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    cfg = cfg_agent::type_id::create("cfg", this);
+    uvm_domain cfg_dom = new("cfg_dom");
+    cfg.set_domain(cfg_dom); // cfg runs in its own domain
+  endfunction
+endclass`}
+  />
+
+  ## Phase Jumping
+
+  UVM allows components to **jump** to another phase. This is rarely used but can
+  be helpful to skip remaining runtime phases when a stopping condition is met.
+
+  <InteractiveCode
+    language="systemverilog"
+    fileName="phase_jump_example.sv"
+    code={`task run_phase(uvm_phase phase);
+  if(stop_simulation)
+    phase.jump(uvm_shutdown_phase::get());
+endtask`}
+  />
 
 </InfoPage>

--- a/content/curriculum/T2_Intermediate/I-UVM-5_Phasing_and_Synchronization/uvm-event-barrier.mdx
+++ b/content/curriculum/T2_Intermediate/I-UVM-5_Phasing_and_Synchronization/uvm-event-barrier.mdx
@@ -1,4 +1,5 @@
 import { InfoPage } from "@/components/templates/InfoPage";
+import { Quiz, InteractiveCode } from "@/components/ui";
 
 export const metadata = {
   title: "uvm_event and uvm_barrier | The UVM Universe - Core Concepts",
@@ -10,8 +11,82 @@ export const metadata = {
   uvm_concept_tags={["uvm_event", "uvm_barrier"]}
 >
 
-  ## uvm_event and uvm_barrier
+  ## uvm_event
 
-  This section is under construction. Please check back later.
+  `uvm_event` provides a simple trigger/wait synchronization. One process calls
+  `trigger()` and another waits with `wait_trigger()`.
+
+  <InteractiveCode
+    language="systemverilog"
+    fileName="uvm_event_example.sv"
+    code={`uvm_event ev = new("ev");
+
+initial begin
+  fork
+    begin
+      #20ns;
+      ev.trigger();
+    end
+    begin
+      ev.wait_trigger();
+      `uvm_info("EV", "Event observed", UVM_LOW)
+    end
+  join_none
+end`}
+  />
+
+  ## uvm_barrier
+
+  A `uvm_barrier` blocks progress until a specified number of processes reach it.
+  The barrier then "opens" and all waiting processes continue.
+
+  <InteractiveCode
+    language="systemverilog"
+    fileName="uvm_barrier_example.sv"
+    code={`uvm_barrier b = new("b", 2);
+
+task run_phase(uvm_phase phase);
+  fork
+    begin
+      // First participant
+      #10ns;
+      b.wait_for();
+    end
+    begin
+      // Second participant
+      #15ns;
+      b.wait_for();
+    end
+  join
+  `uvm_info("BARRIER", "Both processes passed the barrier", UVM_LOW)
+endtask`}
+  />
+
+  <Quiz
+    questions={[
+      {
+        question: "Which method blocks until a uvm_event is triggered?",
+        answers: [
+          { text: "wait_trigger()", correct: true },
+          { text: "trigger()", correct: false },
+          { text: "reset()", correct: false },
+          { text: "jump()", correct: false }
+        ],
+        explanation:
+          "`wait_trigger()` suspends the calling process until `trigger()` is executed."
+      },
+      {
+        question:
+          "A uvm_barrier constructed with a count of 3 will release execution after...",
+        answers: [
+          { text: "Any process calls wait_for()", correct: false },
+          { text: "Three processes call wait_for()", correct: true },
+          { text: "Barrier.reset() is called", correct: false },
+          { text: "The simulation ends", correct: false }
+        ],
+        explanation: "The barrier opens once the specified number of processes arrive."
+      }
+    ]}
+  />
 
 </InfoPage>


### PR DESCRIPTION
## Summary
- explain phase domains and illustrate phase jumping
- document uvm_event and uvm_barrier with code samples
- add quiz covering synchronization primitives

## Testing
- `npm test`
- `npm run lint` *(fails: React hook violations)*

------
https://chatgpt.com/codex/tasks/task_e_6897f4965bb8833096c8db537c7eedca