### PR TITLE
feat: expand foundational sv topics

### DIFF
--- a/content/curriculum/T1_Foundational/F2_Data_Types/user-defined.mdx
+++ b/content/curriculum/T1_Foundational/F2_Data_Types/user-defined.mdx
@@ -1,4 +1,5 @@
 import { InfoPage } from "@/components/templates/InfoPage";
+import { Quiz } from "@/components/ui";
 
 export const metadata = {
   title: "User-Defined Types: structs, unions, enums, typedef | SystemVerilog Language Foundations",
@@ -9,7 +10,57 @@ export const metadata = {
   title="User-Defined Types: structs, unions, enums, typedef"
   sv_concept_tags={["user-defined types", "structs", "unions", "enums", "typedef"]}
 >
+  ## Elevator Pitch
 
-  This section is under construction. Please check back later.
+  User-defined types let you bundle related data or create meaningful names for values, much like building custom-shaped boxes for specific tools. They make code easier to read and enforce structure across your design.
+
+  ## Practical Explanation
+
+  ### Structs and Unions
+
+  ```systemverilog
+  typedef struct {
+    byte  id;
+    logic [7:0] data;
+  } packet_t;            // group fields together
+
+  typedef union packed {
+    byte  b;
+    int   i;
+  } data_u;              // share storage
+
+  packet_t p;
+  data_u   u;
+  ```
+
+  *Structs* hold multiple named fields, while *unions* allow different views of the same bits. Use `typedef` to create aliases like `packet_t` for clarity.
+
+  ### Enumerations
+
+  ```systemverilog
+  typedef enum logic [1:0] {IDLE, READ, WRITE, ERROR} state_t;
+  state_t state = IDLE;
+  ```
+
+  Enums give symbolic names to discrete values. Pair enums with <Link href="/curriculum/T1_Foundational/F2_Data_Types/arrays">arrays</Link> or structs to model state machines and protocol fields.
+
+  ## Advanced Notes
+
+  * Tagged unions (SystemVerilog unions) can be `tagged` for safer type checking.
+  * Use `typedef` to simplify complex declarations and enable reuse across files or <Link href="/curriculum/T1_Foundational/F4_RTL_and_Testbench_Constructs/packages">packages</Link>.
+  * Enums can specify encoding and have methods like `name()` to aid debugging.
+
+  <Quiz questions={[
+    {
+      question: "Which construct provides symbolic names for discrete values?",
+      answers: [
+        { text: "struct", correct: false },
+        { text: "union", correct: false },
+        { text: "enum", correct: true },
+        { text: "typedef", correct: false }
+      ],
+      explanation: "Enums map names to specific values, improving readability and safety."
+    }
+  ]} />
 
 </InfoPage>

--- a/content/curriculum/T1_Foundational/F3_Procedural_Constructs/flow-control.mdx
+++ b/content/curriculum/T1_Foundational/F3_Procedural_Constructs/flow-control.mdx
@@ -1,4 +1,5 @@
 import { InfoPage } from "@/components/templates/InfoPage";
+import { Quiz } from "@/components/ui";
 
 export const metadata = {
   title: "Procedural Flow Control | SystemVerilog Language Foundations",
@@ -9,9 +10,53 @@ export const metadata = {
   title="Procedural Flow Control"
   sv_concept_tags={["procedural flow control", "if", "case", "loops"]}
 >
+  ## Elevator Pitch
 
-  ## Procedural Flow Control
+  Flow control statements decide which lines of code run and how often—much like traffic lights and roundabouts directing cars on a road.
 
-  This section is under construction. Please check back later.
+  ## Practical Explanation
+
+  ```systemverilog
+  int i;
+
+  if (i == 0) begin
+    $display("zero");
+  end else begin
+    $display("non-zero");
+  end
+
+  case (i)
+    1: $display("one");
+    2,3: $display("two or three");
+    default: $display("other");
+  endcase
+
+  repeat (4) begin
+    i++;
+  end
+  ```
+
+  * `if/else` chooses between branches.
+  * `case` matches against multiple values.
+  * Loops like `for`, `repeat`, and `while` run code repeatedly. Use them inside <Link href="/curriculum/T1_Foundational/F3_Procedural_Constructs/tasks-functions">tasks or functions</Link> to build reusable behavior.
+
+  ## Advanced Notes
+
+  * The `unique`/`priority` keywords warn about overlapping or missing `case` branches.
+  * `forever` loops require an explicit `break` or `disable` to exit.
+  * Avoid unintended latches by covering every branch in combinational always blocks.
+
+  <Quiz questions={[
+    {
+      question: "Which loop guarantees at least one iteration?",
+      answers: [
+        { text: "for", correct: false },
+        { text: "repeat", correct: false },
+        { text: "do...while", correct: true },
+        { text: "while", correct: false }
+      ],
+      explanation: "A do...while loop executes its body before checking the condition."
+    }
+  ]} />
 
 </InfoPage>

--- a/content/curriculum/T1_Foundational/F3_Procedural_Constructs/tasks-functions.mdx
+++ b/content/curriculum/T1_Foundational/F3_Procedural_Constructs/tasks-functions.mdx
@@ -1,4 +1,5 @@
 import { InfoPage } from "@/components/templates/InfoPage";
+import { Quiz } from "@/components/ui";
 
 export const metadata = {
   title: "Tasks and Functions: Scoping and Lifetimes | SystemVerilog Language Foundations",
@@ -9,9 +10,48 @@ export const metadata = {
   title="Tasks and Functions: Scoping and Lifetimes"
   sv_concept_tags={["tasks", "functions", "scoping", "lifetimes"]}
 >
+  ## Elevator Pitch
 
-  ## Tasks and Functions: Scoping and Lifetimes
+  Tasks and functions are reusable blocks of code: functions return a value and execute instantly; tasks can consume time and handle more complex behavior. Think of them as recipes—functions are quick snacks, while tasks are multi-step meals.
 
-  This section is under construction. Please check back later.
+  ## Practical Explanation
+
+  ```systemverilog
+  function int add(input int a, b);
+    return a + b;        // no timing allowed
+  endfunction
+
+  task automatic delay_and_print(input int val);
+    #5 $display("val=%0d", val); // tasks may include delays
+  endtask
+
+  initial begin
+    int result = add(2,3);
+    delay_and_print(result);
+  end
+  ```
+
+  *Functions* must finish without timing controls and return a single value. *Tasks* may contain delays and spawn parallel processes. Declaring them `automatic` ensures each call has its own storage, avoiding race conditions.
+
+  For organized code, place common tasks/functions inside <Link href="/curriculum/T1_Foundational/F4_RTL_and_Testbench_Constructs/packages">packages</Link> so multiple modules can share them.
+
+  ## Advanced Notes
+
+  * `automatic` vs `static` controls re-entrancy and variable lifetime.
+  * Use `void'(function_call())` to ignore return values.
+  * Tasks can be declared `forkjoin` style to wait for parallel operations to complete.
+
+  <Quiz questions={[
+    {
+      question: "Which construct can include `#5` delays?",
+      answers: [
+        { text: "function", correct: false },
+        { text: "task", correct: true },
+        { text: "enum", correct: false },
+        { text: "module", correct: false }
+      ],
+      explanation: "Tasks may consume simulation time, while functions must execute without delays."
+    }
+  ]} />
 
 </InfoPage>

--- a/content/curriculum/T1_Foundational/F4_RTL_and_Testbench_Constructs/packages.mdx
+++ b/content/curriculum/T1_Foundational/F4_RTL_and_Testbench_Constructs/packages.mdx
@@ -1,4 +1,5 @@
 import { InfoPage } from "@/components/templates/InfoPage";
+import { Quiz } from "@/components/ui";
 
 export const metadata = {
   title: "Packages and Compilation Scopes | SystemVerilog Language Foundations",
@@ -9,9 +10,46 @@ export const metadata = {
   title="Packages and Compilation Scopes"
   sv_concept_tags={["packages", "compilation scopes"]}
 >
+  ## Elevator Pitch
 
-  ## Packages and Compilation Scopes
+  Packages bundle related declarations—types, parameters, and functions—so they can be shared like a toolbox across many files.
 
-  This section is under construction. Please check back later.
+  ## Practical Explanation
+
+  ```systemverilog
+  package math_pkg;
+    typedef enum {ADD, SUB} op_t;
+    function int do_math(op_t op, int a, b);
+      return (op == ADD) ? a + b : a - b;
+    endfunction
+  endpackage : math_pkg
+
+  import math_pkg::*;   // bring everything into scope
+
+  module top;
+    initial $display("%0d", do_math(ADD, 2, 1));
+  endmodule
+  ```
+
+  Declaring code inside a `package` keeps names organized. Other files access its contents using `import pkg::*` or `import pkg::symbol`. Packages are often placed in separate files and compiled before modules that use them.
+
+  ## Advanced Notes
+
+  * Packages form their own compilation scope; identical names in different packages coexist peacefully.
+  * Use `export pkg::*;` within a package to re-export symbols from another package.
+  * Avoid wildcard imports in large projects to prevent name collisions; list needed symbols explicitly.
+
+  <Quiz questions={[
+    {
+      question: "Which statement brings all declarations from `my_pkg` into the current scope?",
+      answers: [
+        { text: "use my_pkg::*;", correct: false },
+        { text: "import my_pkg::*;", correct: true },
+        { text: "include my_pkg;", correct: false },
+        { text: "export my_pkg::*;", correct: false }
+      ],
+      explanation: "`import my_pkg::*;` makes every symbol in `my_pkg` visible in the current scope."
+    }
+  ]} />
 
 </InfoPage>

--- a/content/curriculum/T2_Intermediate/I-UVM-5_Phasing_and_Synchronization/domains-phase-jumping.mdx
+++ b/content/curriculum/T2_Intermediate/I-UVM-5_Phasing_and_Synchronization/domains-phase-jumping.mdx
@@ -1,5 +1,5 @@
 import { InfoPage } from "@/components/templates/InfoPage";
-import { InteractiveCode } from "@/components/ui";
+import { InteractiveCode, Quiz } from "@/components/ui";
 
 export const metadata = {
   title: "Domains and Phase Jumping | The UVM Universe - Core Concepts",
@@ -50,6 +50,52 @@ endclass`}
   if(stop_simulation)
     phase.jump(uvm_shutdown_phase::get());
 endtask`}
+  />
+
+  ## Level 3: Expert Notes
+
+  - A phase jump only affects components within the same domain; other domains
+    continue their schedules.
+  - Use jumps sparingly—skipping cleanup phases can leave files open or threads
+    running.
+  - Pair domain-specific components with synchronization primitives like
+    <Link href="/curriculum/T2_Intermediate/I-UVM-5_Phasing_and_Synchronization/uvm-event-barrier">`uvm_event`</Link>
+    to coordinate cross-domain actions.
+
+  ## Check Your Understanding
+
+  <Quiz
+    questions={[
+      {
+        question:
+          "Why create a custom phase domain for a configuration agent?",
+        answers: [
+          { text: "To randomize data faster", correct: false },
+          {
+            text: "To let it run a different phase schedule than the rest of the environment",
+            correct: true,
+          },
+          { text: "To disable the UVM factory", correct: false },
+          { text: "To avoid using objections", correct: false },
+        ],
+        explanation:
+          "Custom domains let selected components execute independent phase sequences.",
+      },
+      {
+        question: "What risk comes with jumping directly to `uvm_shutdown_phase`?",
+        answers: [
+          {
+            text: "Pending cleanup in later phases might be skipped",
+            correct: true,
+          },
+          { text: "Other domains will also jump automatically", correct: false },
+          { text: "The simulation time resets to zero", correct: false },
+          { text: "The factory overrides are lost", correct: false },
+        ],
+        explanation:
+          "Jumping phases bypasses remaining scheduled phases for that domain, so cleanup code may not run.",
+      },
+    ]}
   />
 
 </InfoPage>


### PR DESCRIPTION
## Summary
- flesh out user-defined types page with struct, union, enum examples and a quiz
- explain procedural flow control with examples of if/case/loops plus advanced tips and quiz
- detail tasks, functions, and packages including advanced notes and quizzes
- expand phasing with domain separation, phase jumping expert notes, and a quiz

## Testing
- `npm test`
- `npm run build`
- `node check_pages.js`


------
https://chatgpt.com/codex/tasks/task_e_6897f2a3b2448330953770007106269e