### PR TITLE
DX-2: centralize Prisma client usage

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -28,7 +28,7 @@ This file consolidates open implementation and feedback items so the team has a 
 | M4 | todo | Documentation | Write ADRs for routing, state management, and asset strategy. | Keep decisions lightweight but searchable. |
 | QA-4 | completed | Testing | Add or update unit, integration, and E2E tests alongside new features or feedback fixes. | Added a Vitest suite for the bundle guard CLI and refreshed E2E selectors to align with the new accessibility hooks. |
 | QA-5 | ready-for-review | Testing | Extract shared time mocking helpers for deterministic scheduling tests. | Added `tests/setup/time-travel.ts` with `withFrozenTime`; SRS actions spec now uses the shared helper. |
-| DX-2 | todo | DX | Consolidate Prisma client management for server actions. | Avoid per-action instantiation uncovered while expanding SRS coverage. |
+| DX-2 | ready-for-review | DX | Consolidate Prisma client management for server actions. | Avoid per-action instantiation uncovered while expanding SRS coverage. |
 | PROD-1 | todo | Product | Expand placement quiz into an interactive assessment with scoring/analytics. | Next evolution of `/quiz/placement`. |
 | PROD-2 | todo | Product | Power notifications with real activity events and user preferences. | Replace placeholders with real data. |
 | PROD-3 | todo | Product | Replace settings stub with persisted profile/theme/communication preferences. | Integrate with existing auth/session flows. |

--- a/prompt_to_resume.txt
+++ b/prompt_to_resume.txt
@@ -15,7 +15,7 @@
 **Key Open Issues**
 - Playwright browsers install automatically, but `npm run test:e2e` still fails here because `npx playwright install-deps` cannot satisfy the required apt packages behind the proxy (`OPS-1`). Rerun once the host has `libatk`, `libxkbcommon`, audio libs, etc.
 - Re-enable ESLint during builds once remaining lint warnings are cleared (`M1-2`).
-- Shared time mocking helper now lives in `tests/setup/time-travel.ts` (`QA-5` ready for review); still need to refactor Prisma client usage in server actions (`DX-2`).
+- Shared time mocking helper now lives in `tests/setup/time-travel.ts` (`QA-5` ready for review); Prisma client usage is centralized via `src/lib/prisma.ts` (DX-2 now ready for review).
 
 - Before committing: `npm run lint`, `npm run test`, `CI=1 ANALYZE=true npm run build`, `npm run bundle:check`, `npm run test:e2e`.
 - If the host allows, run `npx playwright install-deps && npx playwright install` prior to Playwright runs; otherwise expect the launch failure noted above.

--- a/src/app/actions/notebook.ts
+++ b/src/app/actions/notebook.ts
@@ -1,12 +1,9 @@
 'use server';
 
-import { PrismaClient } from '@prisma/client';
 import { getIronSession } from 'iron-session';
 import { sessionOptions } from '@/lib/session-options';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
-
-const prisma = new PrismaClient();
 
 import { getSession } from '@/lib/session';
 

--- a/src/app/actions/srs.ts
+++ b/src/app/actions/srs.ts
@@ -1,12 +1,11 @@
 'use server';
 
-import { PrismaClient } from '@prisma/client';
 import { getIronSession } from 'iron-session';
 import { sessionOptions } from '@/lib/session-options';
 import { revalidatePath } from 'next/cache.js';
 import { cookies } from 'next/headers.js';
 
-const prisma = new PrismaClient();
+import { prisma } from '@/lib/prisma';
 
 import { getSession } from '@/lib/session';
 

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,12 @@
+import { PrismaClient } from '@prisma/client';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var prisma: PrismaClient | undefined;
+}
+
+export const prisma = globalThis.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') {
+  globalThis.prisma = prisma;
+}

--- a/tests/srs.spec.ts
+++ b/tests/srs.spec.ts
@@ -1,21 +1,20 @@
 /// <reference types="vitest/globals" />
 import { describe, it, expect, vi, Mock } from 'vitest';
 import { createFlashcard, reviewFlashcard, getDueFlashcards } from '../src/app/actions/srs';
-import { PrismaClient } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
 import { withFrozenTime } from './setup/time-travel';
 
-// Mock Prisma Client
-vi.mock('@prisma/client', () => {
-  const mPrismaClient = {
-    flashcard: {
-      create: vi.fn(),
-      findUnique: vi.fn(),
-      update: vi.fn(),
-      findMany: vi.fn(),
-    },
-  };
-  return { PrismaClient: vi.fn(() => mPrismaClient) };
-});
+const mPrismaClient = {
+  flashcard: {
+    create: vi.fn(),
+    findUnique: vi.fn(),
+    update: vi.fn(),
+    findMany: vi.fn(),
+  },
+};
+
+// Mock Prisma Client helper
+vi.mock('@/lib/prisma', () => ({ prisma: mPrismaClient }));
 
 // Mock iron-session
 vi.mock('iron-session', () => ({
@@ -34,8 +33,6 @@ vi.mock('next/cache', () => ({
 }));
 
 describe('SRS Actions', () => {
-  const prisma = new PrismaClient();
-
   it('should create a flashcard', async () => {
     const topicId = 'test-topic-id';
     const expectedFlashcard = {


### PR DESCRIPTION
## Summary
- add a shared Prisma client helper with a hot-reload-safe singleton
- update server actions to depend on the shared Prisma instance
- adjust SRS tests and task trackers to reflect the consolidated client usage

## Testing
- ⚠️ `npm run lint` *(not run in this environment)*
- ⚠️ `npm test` *(not run in this environment)*
- ⚠️ `npm run build` *(not run in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd085b4788330abe9f960a8968a70