### PR TITLE
M1-2: Restore ESLint gating in production builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ npm run build
 npm start
 ```
 
+`npm run build` runs the TypeScript compiler before invoking `next build`; ESLint now executes during the build step, so any lint errors will fail the production build.
+
 ### Docker
 
 ```bash

--- a/TASKS.md
+++ b/TASKS.md
@@ -14,7 +14,7 @@ This file consolidates open implementation and feedback items so the team has a 
 | L4 | completed | Curriculum UX | Restore a performant verification stack visualization or keep refining the quick-link fallback. | Lightweight interactive diagram shipped alongside upgraded placeholders and passing E2E coverage; curriculum quick links stay in sync with the visualization. |
 | NF-5 | todo | Curriculum UX | Replace temporary diagram link targets with real curriculum anchors. | Run after L4 so nodes resolve to finalized slugs. |
 | M1-1 | completed | Build Quality | Re-enable TypeScript error checking during builds. | `npm run build` now gates on `tsc --noEmit` before `next build`, re-enabling the TypeScript fail-fast guard in CI. |
-| M1-2 | todo | Build Quality | Re-enable ESLint error checking during builds. | Remove `ignoreDuringBuilds`, clean lint errors once M1-1 succeeds. |
+| M1-2 | ready-for-review | Build Quality | Re-enable ESLint error checking during builds. | ESLint now runs (and fails) during `next build`; repo is lint-clean. |
 | P1 | completed | Performance | Finish lazy-loading remaining heavy components. | EngagementEngine now defers its Recharts activity graph via `next/dynamic`, keeping the dashboard shell lightweight until the chart loads. |
 | P2 | completed | Performance | Capture bundle stats post-D3 modularization. | Added JSON bundle analysis via `ANALYZE=true` builds, captured a baseline in `docs/bundle-baseline.json`, and wired a `bundle:check` script plus tests to enforce budgets. |
 | P3 | todo | Performance | Standardize on a single charting library (prefer D3). | Re-implement Recharts surfaces or retire them. |

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -26,6 +26,9 @@ try {
 const nextConfig = {
   // Add your Next.js config options here
   output: 'standalone',
+  eslint: {
+    ignoreDuringBuilds: false,
+  },
 
   webpack(config) {
     config.module.rules.push({

--- a/prompt_to_resume.txt
+++ b/prompt_to_resume.txt
@@ -14,7 +14,7 @@
 
 **Key Open Issues**
 - Playwright browsers install automatically, but `npm run test:e2e` still fails here because `npx playwright install-deps` cannot satisfy the required apt packages behind the proxy (`OPS-1`). Rerun once the host has `libatk`, `libxkbcommon`, audio libs, etc.
-- Re-enable ESLint during builds once remaining lint warnings are cleared (`M1-2`).
+- Production builds now run ESLint; keep the repo lint-clean before shipping (`M1-2` ready for review).
 - Shared time mocking helper now lives in `tests/setup/time-travel.ts` (`QA-5` ready for review); still need to refactor Prisma client usage in server actions (`DX-2`).
 
 - Before committing: `npm run lint`, `npm run test`, `CI=1 ANALYZE=true npm run build`, `npm run bundle:check`, `npm run test:e2e`.


### PR DESCRIPTION
## Summary
- explicitly re-enable Next.js ESLint gating during `next build` and document the behavior for contributors
- update task tracking and handoff notes to reflect the restored lint gate for M1-2

## Testing
- [x] `npm run lint`
- [ ] `npm run type-check`
- [ ] `npm run test`
- [x] Additional targeted checks: `CI=1 npm run build`

## Checklist
- [ ] Topic pages follow the Quick Take → References & Next Topics structure (`docs/topic-template.mdx`).
- [ ] Updated `docs/topic-template-migration.md` for any migrated curriculum pages.
- [ ] Visual/interaction changes follow the guidance in `docs/visual-design-guide.md` and include accessible states.
- [ ] Planning docs (`TODO.md`, `MASTER_PLAN.md`, trackers) reflect the change where needed.
- [ ] Attached screenshots, GIFs, or walkthroughs for notable UI updates.
- [ ] Ran `npm run audit:uvm-factory` when touching UVM sources.
- [ ] I have reviewed the full [PR checklist](../docs/pr-checklist.md).

------
https://chatgpt.com/codex/tasks/task_e_68dcd01e05888330bcd37fc7d049fa7e