### PR TITLE
P5: finalize next/font handoff

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -19,7 +19,7 @@ This file consolidates open implementation and feedback items so the team has a 
 | P2 | completed | Performance | Capture bundle stats post-D3 modularization. | Added JSON bundle analysis via `ANALYZE=true` builds, captured a baseline in `docs/bundle-baseline.json`, and wired a `bundle:check` script plus tests to enforce budgets. |
 | P3 | todo | Performance | Standardize on a single charting library (prefer D3). | Re-implement Recharts surfaces or retire them. |
 | P4 | todo | Performance | Implement image optimization using `next/image`. | Audit `<img>` usage and prioritize LCP assets. |
-| P5 | todo | Performance | Optimize font loading with `next/font`. | Ensure `font-display: swap` and preload critical fonts. |
+| P5 | completed | Performance | Optimize font loading with `next/font`. | Implemented centralized `next/font` loaders for Cal Sans, Inter, and JetBrains Mono with swap behavior plus Tailwind fallbacks. |
 | D1 | completed | Platform Stability | Guard `InteractiveCode` so SSR never touches `window`. | Confirm curriculum slugs render without 500s in `next build`. |
 | D3 | todo | DX | Automate local setup and document Playwright/browser prerequisites. | Add `.env.example`, README getting started, and `postinstall` hook for `npx playwright install`. |
 | M1 | completed | Testing | Refactor remaining Playwright specs to use unique, stable locators. | Updated navigation, labs, and interactive demo specs to rely on accessible roles/test ids with matching aria hooks in the UI. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,6 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
-        "@fontsource/inter": "^5.2.6",
-        "@fontsource/jetbrains-mono": "^5.2.6",
         "@google/gemini-cli": "^0.1.15",
         "@google/generative-ai": "^0.24.1",
         "@monaco-editor/react": "^4.7.0",
@@ -3289,24 +3287,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
-    },
-    "node_modules/@fontsource/inter": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.6.tgz",
-      "integrity": "sha512-CZs9S1CrjD0jPwsNy9W6j0BhsmRSQrgwlTNkgQXTsAeDRM42LBRLo3eo9gCzfH4GvV7zpyf78Ozfl773826csw==",
-      "license": "OFL-1.1",
-      "funding": {
-        "url": "https://github.com/sponsors/ayuhito"
-      }
-    },
-    "node_modules/@fontsource/jetbrains-mono": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.6.tgz",
-      "integrity": "sha512-nz//dBr99hXZmHp10wgNI00qThWImkzRR5PQjvRM+rpmuHO5rYBJCqPPWufidCvmkkryXx/GOP/lgqsM3R3Org==",
-      "license": "OFL-1.1",
-      "funding": {
-        "url": "https://github.com/sponsors/ayuhito"
-      }
     },
     "node_modules/@google/gemini-cli": {
       "version": "0.1.15",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,6 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@fontsource/inter": "^5.2.6",
-    "@fontsource/jetbrains-mono": "^5.2.6",
     "@google/gemini-cli": "^0.1.15",
     "@google/generative-ai": "^0.24.1",
     "@monaco-editor/react": "^4.7.0",

--- a/prompt_to_resume.txt
+++ b/prompt_to_resume.txt
@@ -39,6 +39,17 @@
 - Verification stack quick links now resolve to anchored curriculum sections; unit spec updated to allow fragment targets while keeping URL validation in place.
 - Added a "Tests Configure the Run" subsection to the UVM testbench lesson to back the new anchors and dropped a manual anchor in the sequences lesson for handshake stability.
 
-**Follow-ups**
+**Follow-ups – NF-5**
 - Keep an eye on future curriculum edits so the `tests-configure-the-run` and `sequencer-and-driver-handshake` anchors stay intact; update the link map if sections move.
 - Once more verification lessons gain dedicated anchors, expand the map to cover remaining diagram nodes.
+**Latest Update – P5**
+- Audited font loading in the app shell, Tailwind config, and global styles; no legacy `@import` rules remain after centralizing loaders.
+- Added `src/app/fonts.ts` with `next/font/local` for Cal Sans, Inter (400/700), and JetBrains Mono (400/700) plus swap display and preloading.
+- Updated Tailwind font families to use the exported CSS variables with system fallbacks and removed unused `@fontsource/*` dependencies.
+- Pointed the code syntax theme at the JetBrains Mono CSS variable so code blocks render with the same stack as `font-mono` utilities.
+- Ran `npm run lint`, `npm run test`, `CI=1 ANALYZE=true npm run build`, and `npm run bundle:check`; Playwright remains blocked pending system libs (`OPS-1`).
+
+**Follow-ups – P5**
+- Validate downstream consumers (e.g., syntax highlighting themes, `Logo`) continue to use the exported CSS variables—update any lingering `--font-*` references if regressions surface.
+- Consider exporting a woff2 version of Cal Sans for lighter payloads in a future pass once design confirms the weight/axis needs.
+- Re-run a real-browser audit after `OPS-1` unblocks Playwright to confirm rendered font stacks and swap behavior in CI logs.

--- a/src/app/fonts.ts
+++ b/src/app/fonts.ts
@@ -1,0 +1,52 @@
+import localFont from "next/font/local";
+
+/**
+ * Centralized font loading for the application shell.
+ *
+ * We prefer local assets for determinism while still
+ * relying on `next/font` so class names and fallbacks
+ * stay optimized at build-time.
+ */
+export const inter = localFont({
+  src: [
+    {
+      path: "../../public/fonts/inter/inter-latin-400-normal.woff2",
+      weight: "400",
+      style: "normal",
+    },
+    {
+      path: "../../public/fonts/inter/inter-latin-700-normal.woff2",
+      weight: "700",
+      style: "normal",
+    },
+  ],
+  variable: "--font-inter",
+  display: "swap",
+  preload: true,
+});
+
+export const jetBrainsMono = localFont({
+  src: [
+    {
+      path: "../../public/fonts/jetbrains-mono/jetbrains-mono-latin-400-normal.woff2",
+      weight: "400",
+      style: "normal",
+    },
+    {
+      path: "../../public/fonts/jetbrains-mono/jetbrains-mono-latin-700-normal.woff2",
+      weight: "700",
+      style: "normal",
+    },
+  ],
+  variable: "--font-jetbrains-mono",
+  display: "swap",
+  preload: true,
+});
+
+export const calSans = localFont({
+  src: "../../public/fonts/CalSans-SemiBold.otf",
+  variable: "--font-cal-sans",
+  weight: "600",
+  display: "swap",
+  preload: true,
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,64 +1,19 @@
 import type { Metadata } from "next";
-import localFont from 'next/font/local';
-
-// Use local copies of fonts from @fontsource to avoid network issues
-const inter = localFont({
-  src: [
-    {
-      path: '../../public/fonts/inter/inter-latin-400-normal.woff2',
-      weight: '400',
-      style: 'normal',
-    },
-    {
-      path: '../../public/fonts/inter/inter-latin-700-normal.woff2',
-      weight: '700',
-      style: 'normal',
-    },
-  ],
-  variable: '--font-inter',
-  display: 'swap',
-});
-
-const jetbrains_mono = localFont({
-  src: [
-    {
-      path: '../../public/fonts/jetbrains-mono/jetbrains-mono-latin-400-normal.woff2',
-      weight: '400',
-      style: 'normal',
-    },
-    {
-      path: '../../public/fonts/jetbrains-mono/jetbrains-mono-latin-700-normal.woff2',
-      weight: '700',
-      style: 'normal',
-    },
-  ],
-  variable: '--font-jetbrains-mono',
-  display: 'swap',
-});
-// Import AnimatePresence from the client component provider
-import { AnimatePresence } from '@/components/providers/FramerMotionProvider';
 import { ThemeProvider } from "@/components/providers/ThemeProvider";
+import { calSans, inter, jetBrainsMono } from "./fonts";
 import "./globals.css";
 // Navbar and Footer are now part of MainLayout
 import MainLayout from "@/components/layout/MainLayout"; // Corrected Import MainLayout path
-import { SessionProvider } from '@/components/providers/SessionProvider';
-import { AuthProvider } from '@/contexts/AuthContext';
-import { NavigationProvider } from '@/contexts/NavigationContext';
-import Sidebar from '@/components/layout/Sidebar';
-import KeyboardShortcuts from '@/components/layout/KeyboardShortcuts';
+import { SessionProvider } from "@/components/providers/SessionProvider";
+import { AuthProvider } from "@/contexts/AuthContext";
+import { NavigationProvider } from "@/contexts/NavigationContext";
+import Sidebar from "@/components/layout/Sidebar";
+import KeyboardShortcuts from "@/components/layout/KeyboardShortcuts";
 // The AIAssistant (full chat) is removed from global layout for now.
 // The PersistentAITutorButton will be the global widget.
 // import AIAssistant from "@/components/ai/AIAssistant";
 import AIAssistantWidget from "@/components/widgets/AIAssistantWidget";
 
-
-// Assuming Cal Sans will be a local font file
-const calSans = localFont({
-  src: '../../public/fonts/CalSans-SemiBold.otf',
-  variable: '--font-cal-sans',
-  weight: '600',
-  display: 'swap',
-});
 
 export const metadata: Metadata = {
   title: "SystemVerilog & UVM Mastery",
@@ -80,7 +35,7 @@ interface RootLayoutProps {
 export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={`${inter.variable} ${jetbrains_mono.variable} ${calSans.variable} font-sans`}>
+      <body className={`${inter.variable} ${jetBrainsMono.variable} ${calSans.variable} font-sans`}>
         <ThemeProvider attribute="data-theme" defaultTheme="default-dark" disableTransitionOnChange>
           <SessionProvider>
             <AuthProvider>

--- a/src/lib/code-theme.ts
+++ b/src/lib/code-theme.ts
@@ -4,11 +4,13 @@
 // from our Tailwind CSS config. This ensures that code blocks match the
 // application's theme.
 
+const monoStack = "var(--font-jetbrains-mono), ui-monospace, SFMono-Regular, monospace";
+
 export const lightTheme = {
   'code[class*="language-"]': {
     color: "hsl(var(--foreground))",
     background: "hsl(var(--background))",
-    fontFamily: "var(--font-mono)",
+    fontFamily: monoStack,
     textAlign: "left",
     whiteSpace: "pre",
     wordSpacing: "normal",
@@ -26,7 +28,7 @@ export const lightTheme = {
   'pre[class*="language-"]': {
     color: "hsl(var(--foreground))",
     background: "hsl(var(--background))",
-    fontFamily: "var(--font-mono)",
+    fontFamily: monoStack,
     textAlign: "left",
     whiteSpace: "pre",
     wordSpacing: "normal",
@@ -161,7 +163,7 @@ export const darkTheme = {
   'code[class*="language-"]': {
     color: "hsl(var(--foreground))",
     background: "hsl(var(--background))",
-    fontFamily: "var(--font-mono)",
+    fontFamily: monoStack,
     textAlign: "left",
     whiteSpace: "pre",
     wordSpacing: "normal",
@@ -179,7 +181,7 @@ export const darkTheme = {
   'pre[class*="language-"]': {
     color: "hsl(var(--foreground))",
     background: "hsl(var(--background))",
-    fontFamily: "var(--font-mono)",
+    fontFamily: monoStack,
     textAlign: "left",
     whiteSpace: "pre",
     wordSpacing: "normal",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -49,8 +49,18 @@ const config: Config = {
         },
       },
       fontFamily: {
-        sans: ["var(--font-cal-sans)", "var(--font-inter)"],
-        mono: ["var(--font-jetbrains-mono)"],
+        sans: [
+          "var(--font-cal-sans)",
+          "var(--font-inter)",
+          "system-ui",
+          "sans-serif",
+        ],
+        mono: [
+          "var(--font-jetbrains-mono)",
+          "ui-monospace",
+          "SFMono-Regular",
+          "monospace",
+        ],
         serif: ["Georgia", "serif"],
       },
       borderRadius: {


### PR DESCRIPTION
## Summary
- centralize our `next/font` usage in `src/app/fonts.ts` for Cal Sans, Inter, and JetBrains Mono with swap display and preload guarantees
- align Tailwind utilities and the syntax highlighting theme on the shared font CSS variables so JetBrains Mono backs all mono contexts
- mark P5 complete in `TASKS.md` and refresh the handoff notes with updated follow-ups

## Testing
- npm run lint
- npm run test
- CI=1 ANALYZE=true npm run build
- npm run bundle:check

------
https://chatgpt.com/codex/tasks/task_e_68dcf8a831d4833080084fef07dc4587