### PR TITLE
Complete M3 testing polish

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -24,7 +24,7 @@ This file consolidates open implementation and feedback items so the team has a 
 | D3 | todo | DX | Automate local setup and document Playwright/browser prerequisites. | Add `.env.example`, README getting started, and `postinstall` hook for `npx playwright install`. |
 | M1 | completed | Testing | Refactor remaining Playwright specs to use unique, stable locators. | Updated navigation, labs, and interactive demo specs to rely on accessible roles/test ids with matching aria hooks in the UI. |
 | M2 | todo | Testing | Enforce code quality via Husky + lint-staged pre-commit hooks. | Depends on M1-1 and M1-2. |
-| M3 | todo | Testing | Add exemplar unit/integration tests and document strategy. | Seed Vitest coverage for utilities and UI components. |
+| M3 | completed | Testing | Add exemplar unit/integration tests and document strategy. | Seed Vitest coverage for utilities and UI components. |
 | M4 | todo | Documentation | Write ADRs for routing, state management, and asset strategy. | Keep decisions lightweight but searchable. |
 | QA-4 | completed | Testing | Add or update unit, integration, and E2E tests alongside new features or feedback fixes. | Added a Vitest suite for the bundle guard CLI and refreshed E2E selectors to align with the new accessibility hooks. |
 | QA-5 | completed | Testing | Extract shared time mocking helpers for deterministic scheduling tests. | Added `tests/setup/time-travel.ts` with `withFrozenTime`; SRS actions spec now uses the shared helper. |

--- a/docs/planning/testing-strategy.md
+++ b/docs/planning/testing-strategy.md
@@ -1,0 +1,20 @@
+# Automated Testing Strategy
+
+This session focused on filling gaps for recent curriculum and dashboard features so that regressions are caught before they hit production.
+
+## Coverage Targets
+- **Curriculum quick links:** `InteractiveUvmArchitectureDiagram` now has a Rendering test that walks the quick summary controls and verifies that the detail panel and CTA track the active node. This ensures the curriculum anchors stay synchronized with the verification stack map.
+- **Learner progress tracking:** The `useCurriculumProgress` hook is covered with unit tests that assert localStorage hydration, completion tracking, and visit logging. Fixtures keep the module structure deterministic while exercising the production persistence logic.
+- **Dashboard shell:** A Vitest integration spec renders `DashboardPageClient` with a mocked curriculum status feed and checks the derived coverage counts, backlog messaging, and module progress list.
+
+## Patterns & Tooling
+- All specs live in `tests/` alongside existing suites and reuse Testing Library helpers (`render`, `renderHook`, `within`).
+- `next/link` and `next/image` are mocked per-suite to keep component markup shallow and deterministic.
+- Progress hook tests mock `@/lib/curriculum-data` fixtures so calculations can be asserted without loading the entire generated dataset.
+
+## Expansion Plan
+1. **Curriculum experience:** Extend quick-link coverage to the curriculum landing page (`src/app/curriculum/page.tsx`) once filtering logic stabilizes.
+2. **Progress analytics:** Add integration tests for recommendation surfaces that consume `useCurriculumProgress`, especially the tier unlock states when gating rules ship.
+3. **Dashboard telemetry:** When real activity data flows through `buildCurriculumStatus`, promote the mock to a shared factory and add Playwright smoke tests that click through `/dashboard/coverage`.
+
+Keep these suites in the pre-commit loop (`npm run lint`, `npm run test`, `CI=1 ANALYZE=true npm run build`) and capture Playwright output when the system dependencies (`OPS-1`) land.

--- a/prompt_to_resume.txt
+++ b/prompt_to_resume.txt
@@ -39,6 +39,16 @@
 - Verification stack quick links now resolve to anchored curriculum sections; unit spec updated to allow fragment targets while keeping URL validation in place.
 - Added a "Tests Configure the Run" subsection to the UVM testbench lesson to back the new anchors and dropped a manual anchor in the sequences lesson for handshake stability.
 
+**Latest Update – M3**
+- New Vitest suites cover the interactive verification stack quick links, the curriculum progress hook, and the dashboard shell aggregation so regressions surface immediately.
+- Documented the automated testing targets, helper patterns, and expansion plan in `docs/planning/testing-strategy.md` for future contributors.
+- Playwright smoke coverage remains blocked on missing system libraries (`OPS-1`); rerun once the environment can install `npx playwright install-deps` successfully.
+- `TASKS.md` now marks M3 as completed after verifying the coverage additions and documentation landed.
+
+**Coverage Gaps**
+- Curriculum landing page filters and recommendation surfaces still rely on manual checks; expand tests once gating logic ships.
+- Dashboard telemetry still uses stubbed curriculum status data—promote shared fixtures when real analytics feed the UI.
+
 **Follow-ups**
 - Keep an eye on future curriculum edits so the `tests-configure-the-run` and `sequencer-and-driver-handshake` anchors stay intact; update the link map if sections move.
 - Once more verification lessons gain dedicated anchors, expand the map to cover remaining diagram nodes.

--- a/tests/app/dashboard-page.spec.tsx
+++ b/tests/app/dashboard-page.spec.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import type { CurriculumTopicStatus } from '@/lib/curriculum-status';
+
+type MockNextLinkProps = React.PropsWithChildren<
+  Omit<React.ComponentProps<'a'>, 'href'> & { href: string }
+>;
+
+vi.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, children, ...rest }: MockNextLinkProps) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+const baseStatus: CurriculumTopicStatus = {
+  status: 'complete',
+  owner: 'Content Ops',
+  lastUpdated: '2025-09-22',
+  tier: 'T1',
+  moduleSlug: 'T1_Foundational',
+  moduleTitle: 'Foundational',
+  sectionSlug: 'fundamentals',
+  sectionTitle: 'Fundamentals',
+  topicSlug: 'overview',
+  topicTitle: 'Overview',
+  path: 'T1_Foundational/fundamentals/overview',
+  notes: 'Mock entry for dashboard coverage tests.',
+};
+
+const curriculumStatusMock: CurriculumTopicStatus[] = [
+  baseStatus,
+  {
+    ...baseStatus,
+    status: 'in-review',
+    topicSlug: 'agent-handoff',
+    topicTitle: 'Agent handoff drill',
+    path: 'T1_Foundational/fundamentals/agent-handoff',
+  },
+  {
+    ...baseStatus,
+    status: 'draft',
+    topicSlug: 'coverage-outlook',
+    topicTitle: 'Coverage outlook',
+    path: 'T1_Foundational/fundamentals/coverage-outlook',
+  },
+];
+
+vi.mock('@/lib/curriculum-status', () => ({
+  buildCurriculumStatus: () => curriculumStatusMock,
+}));
+
+import DashboardPage from '@/app/dashboard/DashboardPageClient';
+
+describe('DashboardPageClient', () => {
+  it('summarizes curriculum coverage and module progress', () => {
+    render(<DashboardPage />);
+
+    expect(screen.getByText('Welcome back, verification lead')).toBeInTheDocument();
+    expect(screen.getByText('Foundational')).toBeInTheDocument();
+    expect(screen.getByText('Intermediate')).toBeInTheDocument();
+
+    const coverageContainer = screen.getByText('Coverage snapshot').closest('.glass-card');
+    expect(coverageContainer).not.toBeNull();
+
+    const coverageCard = within(coverageContainer as HTMLElement);
+    expect(coverageCard.getByText(/1\/3/)).toBeInTheDocument();
+    expect(coverageCard.getByText('In review')).toBeInTheDocument();
+    expect(coverageCard.getByText('Draft backlog')).toBeInTheDocument();
+    expect(screen.getByText('2 topics still need accuracy or polish before the next push.')).toBeInTheDocument();
+
+    const openDashboard = screen.getByRole('link', { name: /Open dashboard/i });
+    expect(openDashboard.getAttribute('href')).toBe('/dashboard/coverage');
+  });
+});

--- a/tests/components/InteractiveUvmArchitectureDiagram.test.tsx
+++ b/tests/components/InteractiveUvmArchitectureDiagram.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render, screen, within, fireEvent } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import InteractiveUvmArchitectureDiagram from '@/components/diagrams/InteractiveUvmArchitectureDiagram';
+
+type MockNextImageProps = React.ComponentProps<'img'> & { priority?: boolean };
+type MockNextLinkProps = React.PropsWithChildren<
+  Omit<React.ComponentProps<'a'>, 'href'> & { href: string }
+>;
+
+vi.mock('next/image', () => ({
+  __esModule: true,
+  default: ({ alt, priority: _priority, ...props }: MockNextImageProps) => (
+    // eslint-disable-next-line jsx-a11y/alt-text
+    <img alt={alt} {...props} />
+  ),
+}));
+
+vi.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, children, ...rest }: MockNextLinkProps) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+describe('InteractiveUvmArchitectureDiagram', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('syncs the node detail panel with quick summary selections', () => {
+    render(<InteractiveUvmArchitectureDiagram />);
+
+    const detail = screen.getByTestId('uvm-node-detail');
+    expect(detail).toHaveTextContent('UVM Test & Component Basics');
+
+    const summary = screen.getByTestId('uvm-quick-summary');
+    const agentButton = within(summary).getByRole('button', { name: /Agents, Sequencers & Drivers/i });
+
+    fireEvent.click(agentButton);
+
+    expect(detail).toHaveTextContent('Agents, Sequencers & Drivers');
+    expect(detail).toHaveTextContent('Agents bridge stimulus generation and DUT interaction');
+
+    const flowList = screen.getByTestId('uvm-flow-list');
+    const agentFlowButton = within(flowList).getByRole('button', { name: /Agents, Sequencers & Drivers/i });
+    expect(agentFlowButton).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('keeps the lesson CTA aligned with the active node', () => {
+    render(<InteractiveUvmArchitectureDiagram />);
+
+    const flowList = screen.getByTestId('uvm-flow-list');
+    const coverageButton = within(flowList).getByRole('button', { name: /Functional Coverage/i });
+    fireEvent.click(coverageButton);
+
+    const cta = screen.getByRole('link', { name: /Open lesson/i });
+    expect(cta.getAttribute('href')).toBe('/curriculum/T2_Intermediate/I-SV-3_Functional_Coverage/index#core-constructs-in-action');
+  });
+});

--- a/tests/hooks/useCurriculumProgress.test.ts
+++ b/tests/hooks/useCurriculumProgress.test.ts
@@ -1,0 +1,122 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { Lesson, ModuleEntry, Tier } from '@/lib/curriculum-data';
+
+const { lessonFixtures, moduleFixture, tierFixture } = vi.hoisted(() => {
+  const fixtures: Lesson[] = [
+    { title: 'Intro', slug: 'intro', description: '' },
+    { title: 'Deep Dive', slug: 'deep-dive', description: '' },
+    { title: 'Wrap Up', slug: 'wrap-up', description: '' },
+  ];
+
+  const moduleFixture: ModuleEntry = {
+    id: 'module-one',
+    title: 'Module One',
+    slug: 'module-one',
+    lessons: fixtures,
+  };
+
+  const tierFixture: Tier = {
+    title: 'Tier Alpha',
+    slug: 'tier-alpha',
+    tier: 'T1',
+    sections: [
+      {
+        title: moduleFixture.title,
+        slug: moduleFixture.slug,
+        topics: fixtures,
+      },
+    ],
+  };
+
+  return { lessonFixtures: fixtures, moduleFixture, tierFixture };
+});
+
+vi.mock('@/lib/curriculum-data', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/curriculum-data')>(
+    '@/lib/curriculum-data',
+  );
+
+  return {
+    ...actual,
+    tiers: [tierFixture],
+    getModules: (tier: Tier) => {
+      if (tier.slug === tierFixture.slug) {
+        return [moduleFixture];
+      }
+
+      return actual.getModules(tier);
+    },
+  };
+});
+
+// Import after mocking curriculum data so the hook reads the fixtures above.
+import { useCurriculumProgress } from '@/hooks/useCurriculumProgress';
+
+describe('useCurriculumProgress', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.spyOn(Date, 'now').mockReturnValue(1_726_000_000_000);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('restores stored progress and reports module + tier percentages', async () => {
+    localStorage.setItem(
+      'curriculumProgress',
+      JSON.stringify({
+        'module-one': {
+          completedLessons: ['intro'],
+          lastVisitedAt: 1_700_000_000_000,
+          lastVisitedLesson: 'intro',
+        },
+      }),
+    );
+
+    const { result } = renderHook(() => useCurriculumProgress());
+
+    await waitFor(() => expect(result.current.isLoaded).toBe(true));
+
+    expect(result.current.getModuleProgress('module-one')).toBe(33);
+    expect(result.current.getTierProgress('tier-alpha')).toBe(33);
+  });
+
+  it('marks lessons complete and persists the snapshot', async () => {
+    const { result } = renderHook(() => useCurriculumProgress());
+
+    await waitFor(() => expect(result.current.isLoaded).toBe(true));
+
+    act(() => {
+      result.current.completeLesson('module-one', 'deep-dive');
+    });
+
+    await waitFor(() => {
+      const stored = JSON.parse(localStorage.getItem('curriculumProgress') ?? '{}');
+      expect(stored['module-one'].completedLessons).toEqual(['deep-dive']);
+      expect(stored['module-one'].lastVisitedLesson).toBe('deep-dive');
+      expect(stored['module-one'].lastVisitedAt).toBe(1_726_000_000_000);
+    });
+
+    expect(result.current.getModuleProgress('module-one')).toBe(33);
+  });
+
+  it('records lesson visits without marking completion', async () => {
+    const { result } = renderHook(() => useCurriculumProgress());
+
+    await waitFor(() => expect(result.current.isLoaded).toBe(true));
+
+    act(() => {
+      result.current.recordLessonVisit('module-one', 'wrap-up');
+    });
+
+    await waitFor(() => {
+      const stored = JSON.parse(localStorage.getItem('curriculumProgress') ?? '{}');
+      expect(stored['module-one'].completedLessons).toEqual([]);
+      expect(stored['module-one'].lastVisitedLesson).toBe('wrap-up');
+    });
+
+    expect(result.current.getModuleProgress('module-one')).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- type the dashboard coverage Vitest suite’s Next.js link mock and feed it structured `CurriculumTopicStatus` fixtures so the assertions track real metadata
- tighten the interactive UVM architecture diagram tests by giving the mocked link helper proper anchor props
- mark task M3 as completed and mirror the status change in the session handoff notes

## Testing
- npm run lint
- npm test
- CI=1 ANALYZE=true npm run build
- CI=1 npm run test:e2e -- --project=chromium --grep "curriculum" *(fails: curriculum smoke still hits aborted requests in this container)*

------
https://chatgpt.com/codex/tasks/task_e_68dcf8ab98688330adf17ae380ddf9d1