### PR TITLE
fix: complete add two numbers challenge starter code

### DIFF
--- a/src/lib/challenges/index.ts
+++ b/src/lib/challenges/index.ts
@@ -7,7 +7,7 @@ export const challenges: Challenge[] = [
     description: "Return the sum of two numbers.",
     difficulty: "easy",
     starterCode: `function solution(a: number, b: number) {
-  // TODO: return the sum of a and b
+  return a + b;
 }`,
     solution: (a: number, b: number): number => a + b,
     testCases: [


### PR DESCRIPTION
Updates the starter code for the `add-two` challenge in `src/lib/challenges/index.ts` to actually return the sum of `a` and `b` rather than a TODO comment.

---
*PR created automatically by Jules for task [15522367860816012680](https://jules.google.com/task/15522367860816012680) started by @rakeshnreddy*