### PR TITLE
🎨 Palette: Add ARIA labels to Navbar icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-03-15 - [Added Accessible Progress Bars and Controls to Coverage Analyzer]
 **Learning:** Adding ARIA roles to custom visual progress bars (using `role="progressbar"`, `aria-valuenow`, `aria-valuemin`, `aria-valuemax`) drastically improves the screen-reader experience for components that only indicate progress via colored `div` widths. Adding context-specific `aria-label`s to controls like play/pause and selectors makes complex interactives more understandable.
 **Action:** When building custom visual progress indicators, always ensure they are accompanied by the proper `role="progressbar"` and current value attributes, rather than relying on visual CSS properties alone.
+## 2026-03-16 - Missing ARIA Labels on Icon-Only Navigation Buttons
+**Learning:** The application's top-level navigation components (like the Navbar) frequently omit accessible labels for icon-only buttons (e.g., User Profile, Notifications, Search), which breaks screen reader usage for critical application features.
+**Action:** Always ensure icon-only buttons have an appropriate `aria-label` and, for dropdown triggers, an `aria-expanded` attribute.

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -38,6 +38,8 @@ const UserProfileDropdown = () => {
             <button
                 className="rounded-2xl border border-white/10 bg-white/5 p-2 text-[var(--blueprint-foreground)] transition hover:border-white/20 hover:bg-white/10"
                 data-testid="user-profile-button"
+                aria-label="User Profile"
+                aria-expanded={isOpen}
             >
                 <UserCircle className="h-6 w-6" />
             </button>
@@ -131,6 +133,8 @@ const NotificationCenter = () => {
         onClick={() => setIsOpen((prev) => !prev)}
         className="relative rounded-2xl border border-white/10 bg-white/5 p-2 text-[var(--blueprint-foreground)] transition hover:border-white/20 hover:bg-white/10"
         data-testid="notification-button"
+        aria-label="Notifications"
+        aria-expanded={isOpen}
       >
         <Bell className="h-6 w-6" />
         <span className={badgeClass} aria-hidden={!hasUnread} />
@@ -336,7 +340,10 @@ const Navbar = () => {
               <PanelLeft className="h-6 w-6" />
               <span className="sr-only">Open sidebar</span>
             </button>
-            <button className="rounded-2xl border border-white/10 bg-white/5 p-2 text-[var(--blueprint-foreground)] transition hover:border-white/20 hover:bg-white/10">
+            <button
+              className="rounded-2xl border border-white/10 bg-white/5 p-2 text-[var(--blueprint-foreground)] transition hover:border-white/20 hover:bg-white/10"
+              aria-label="Search"
+            >
                 <Search className="h-6 w-6" />
             </button>
             <button
@@ -376,7 +383,11 @@ const Navbar = () => {
                 >
                     <div className="flex items-center justify-between border-b border-white/10 p-4">
                       <h2 className="text-lg font-semibold">Menu</h2>
-                      <button onClick={toggleMobileMenu} className="rounded-2xl border border-white/10 bg-white/5 p-1 text-[var(--blueprint-foreground)] transition hover:border-white/20 hover:bg-white/10">
+                      <button
+                          onClick={toggleMobileMenu}
+                          className="rounded-2xl border border-white/10 bg-white/5 p-1 text-[var(--blueprint-foreground)] transition hover:border-white/20 hover:bg-white/10"
+                          aria-label="Close menu"
+                      >
                           <X className="h-6 w-6" />
                       </button>
                     </div>


### PR DESCRIPTION
💡 **What:** Added `aria-label` to icon-only buttons in the Navbar (User Profile, Notifications, Search, Menu Close). Also added `aria-expanded` to dropdown triggers.

🎯 **Why:** To improve accessibility for screen reader users, who otherwise would have no context for what these critical navigation buttons do.

♿ **Accessibility:** Fixes missing ARIA labels on top-level navigation, making the core app shell accessible.

---
*PR created automatically by Jules for task [11000750971336437073](https://jules.google.com/task/11000750971336437073) started by @rakeshnreddy*