### PR TITLE
⚡ Bolt: Add index on nextReviewAt to speed up Flashcard queries

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,7 +31,8 @@ model Flashcard {
   repetitions   Int      @default(0)
   nextReviewAt  DateTime @default(now())
 
-  @@index([userId])
+  // ⚡ Bolt: Added composite index on userId and nextReviewAt to speed up getDueFlashcards query
+  @@index([userId, nextReviewAt])
 }
 
 model Lab {

--- a/src/components/visuals/VIPReuseVisualizer.tsx
+++ b/src/components/visuals/VIPReuseVisualizer.tsx
@@ -141,21 +141,21 @@ export default function VIPReuseVisualizer() {
         <div className="font-mono text-xs overflow-x-auto whitespace-pre">
           {isPassive ? (
             <span className="text-purple-300">
-              <span className="text-slate-500">// In soc_test::build_phase</span>{'\n'}
+              <span className="text-slate-500">{"// In soc_test::build_phase"}</span>{'\n'}
               uvm_config_db#(uvm_active_passive_enum)::set(this, "*.spi_agent", "is_active", <strong>UVM_PASSIVE</strong>);{'\n'}
-              <span className="text-slate-500 mt-2 block">// Result:
-// - Driver & Sequencer are NOT created.
-// - Monitor continues observing bus traffic driven by SoC processor.</span>
+              <span className="text-slate-500 mt-2 block">{"// Result:\n"}
+{"// - Driver & Sequencer are NOT created.\n"}
+{"// - Monitor continues observing bus traffic driven by SoC processor."}</span>
             </span>
           ) : (
             <span className="text-blue-300">
-              <span className="text-slate-500">// Default behavior in block_test::build_phase</span>{'\n'}
-              <span className="text-slate-500 opacity-60">// uvm_config_db is not required for default active mode,</span>{'\n'}
-              <span className="text-slate-500 opacity-60">// but explicitly looks like:</span>{'\n'}
+              <span className="text-slate-500">{"// Default behavior in block_test::build_phase"}</span>{'\n'}
+              <span className="text-slate-500 opacity-60">{"// uvm_config_db is not required for default active mode,"}</span>{'\n'}
+              <span className="text-slate-500 opacity-60">{"// but explicitly looks like:"}</span>{'\n'}
               uvm_config_db#(uvm_active_passive_enum)::set(this, "*.spi_agent", "is_active", <strong>UVM_ACTIVE</strong>);{'\n'}
-              <span className="text-slate-500 mt-2 block">// Result:
-// - Driver & Sequencer are created.
-// - Driver actively wiggles DUT pins.</span>
+              <span className="text-slate-500 mt-2 block">{"// Result:\n"}
+{"// - Driver & Sequencer are created.\n"}
+{"// - Driver actively wiggles DUT pins."}</span>
             </span>
           )}
         </div>


### PR DESCRIPTION
💡 What: Added a composite index on `[userId, nextReviewAt]` in the Prisma `Flashcard` schema. Also resolved a minor JSX comment text node linter warning in `VIPReuseVisualizer.tsx`.
🎯 Why: `getDueFlashcards` queries heavily filter and sort on `userId` and `nextReviewAt` at the same time.
📊 Impact: Expected performance improvement in fetching spaced-repetition flashcards by allowing database to leverage index during query execution.
🔬 Measurement: Run the query with a full database of Flashcards and examine query plans with and without the index using `EXPLAIN`.

---
*PR created automatically by Jules for task [1652107490666987854](https://jules.google.com/task/1652107490666987854) started by @rakeshnreddy*