### PR TITLE
🎨 Palette: add aria-expanded to module outline button

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -196,13 +196,19 @@ const Sidebar = () => {
               {/* Module Outline */}
               {moduleOutline && moduleOutline.sections.length > 0 && (
                 <div>
-                  <button onClick={() => setOutlineOpen(!isOutlineOpen)} className="w-full flex justify-between items-center font-semibold text-left mb-2">
+                  <button
+                    onClick={() => setOutlineOpen(!isOutlineOpen)}
+                    className="w-full flex justify-between items-center font-semibold text-left mb-2"
+                    aria-expanded={isOutlineOpen}
+                    aria-controls="module-outline-content"
+                  >
                     <span>Module Outline</span>
                     <ChevronsUpDown className={`h-4 w-4 transition-transform ${isOutlineOpen ? 'rotate-180' : ''}`} />
                   </button>
                   <AnimatePresence>
                     {isOutlineOpen && (
                       <motion.div
+                        id="module-outline-content"
                         initial={{ height: 0, opacity: 0 }}
                         animate={{ height: 'auto', opacity: 1 }}
                         exit={{ height: 0, opacity: 0 }}


### PR DESCRIPTION
💡 What: Added `aria-expanded` and `aria-controls` attributes to the "Module Outline" collapsible button in the Sidebar component. Also added an `id` to the content container to link them together.
🎯 Why: Screen reader users need to know if a collapsible section is currently expanded or collapsed. The `aria-expanded` attribute conveys this state, and `aria-controls` links the trigger to the content it toggles.
📸 Before/After: Visual appearance is unchanged.
♿ Accessibility: Improves accessibility for screen readers by exposing the expanded/collapsed state of the Module Outline dropdown.

---
*PR created automatically by Jules for task [17726113842879703051](https://jules.google.com/task/17726113842879703051) started by @rakeshnreddy*