### PR TITLE
🎨 Palette: Add aria-label to Search button in mobile Navbar

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -336,7 +336,7 @@ const Navbar = () => {
               <PanelLeft className="h-6 w-6" />
               <span className="sr-only">Open sidebar</span>
             </button>
-            <button className="rounded-2xl border border-white/10 bg-white/5 p-2 text-[var(--blueprint-foreground)] transition hover:border-white/20 hover:bg-white/10">
+            <button aria-label="Search" className="rounded-2xl border border-white/10 bg-white/5 p-2 text-[var(--blueprint-foreground)] transition hover:border-white/20 hover:bg-white/10">
                 <Search className="h-6 w-6" />
             </button>
             <button


### PR DESCRIPTION
💡 What: Added an `aria-label="Search"` to the mobile navigation search button.
🎯 Why: It was an icon-only button without an accessible name, making it invisible/unintelligible to screen readers.
📸 Before/After: Visuals remain unchanged.
♿ Accessibility: Ensures the mobile search button is properly announced by screen readers.

---
*PR created automatically by Jules for task [5867996381069183257](https://jules.google.com/task/5867996381069183257) started by @rakeshnreddy*